### PR TITLE
✨Feat: CODEF 자녀 등록 API (1차/2차 인증) 및 연동 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.5'
+    id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     // spotless 추가
     id "com.diffplug.spotless" version "6.19.0"
@@ -67,6 +67,9 @@ dependencies {
 
     // Swagger openapi-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
+
+    // Webclient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/springboot/iboribe/domain/codef/client/CodefClient.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/client/CodefClient.java
@@ -1,0 +1,143 @@
+package com.springboot.iboribe.domain.codef.client;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegister2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegisterRequest;
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
+import com.springboot.iboribe.domain.codef.exception.CodefErrorCode;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CodefClient {
+
+  private static final String CHILD_REGISTER_URI =
+      "/v1/kr/public/pp/nhis-family-health/child-register";
+
+  private final WebClient webClient;
+  private final ObjectMapper objectMapper;
+  private final String accessToken;
+
+  public CodefClient(
+      WebClient.Builder webClientBuilder,
+      ObjectMapper objectMapper,
+      @Value("${codef.base-url}") String baseUrl,
+      @Value("${codef.access-token}") String accessToken) {
+    this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+    this.objectMapper = objectMapper;
+    this.accessToken = accessToken;
+  }
+
+  public CodefChildRegisterResponse registerChild(CodefChildRegisterRequest request) {
+    String responseBody = callCodef(request);
+    Map<String, Object> response = parseResponse(responseBody);
+
+    return toChildRegisterResponse(response);
+  }
+
+  public CodefChildRegisterResponse registerChild2Way(CodefChildRegister2WayRequest request) {
+    Map<String, Object> body = new HashMap<>();
+
+    body.put("organization", request.getOrganization());
+    body.put("loginType", request.getLoginType());
+    body.put("loginTypeLevel", request.getLoginTypeLevel());
+    body.put("userName", request.getUserName());
+    body.put("identity", request.getIdentity());
+    body.put("phoneNo", request.getPhoneNo());
+    body.put("telecom", request.getTelecom());
+    body.put("id", request.getId());
+
+    body.put("simpleAuth", request.getSimpleAuth());
+    body.put("childName", request.getChildName());
+    body.put("is2Way", true);
+    body.put("twoWayInfo", request.getTwoWayInfo());
+
+    String responseBody = callCodef(body);
+    Map<String, Object> response = parseResponse(responseBody);
+
+    return toChildRegisterResponse(response);
+  }
+
+  private String callCodef(Object requestBody) {
+    return webClient
+        .post()
+        .uri(CHILD_REGISTER_URI)
+        .contentType(MediaType.APPLICATION_JSON)
+        .header("Authorization", "Bearer " + accessToken)
+        .bodyValue(requestBody)
+        .retrieve()
+        .bodyToMono(String.class)
+        .timeout(Duration.ofSeconds(300))
+        .onErrorMap(
+            TimeoutException.class, e -> new CustomException(CodefErrorCode.CODEF_API_TIMEOUT))
+        .block();
+  }
+
+  private Map<String, Object> parseResponse(String responseBody) {
+    if (responseBody == null) {
+      throw new CustomException(CodefErrorCode.CODEF_EMPTY_RESPONSE);
+    }
+
+    String decodedResponseBody = URLDecoder.decode(responseBody, StandardCharsets.UTF_8);
+
+    try {
+      return objectMapper.readValue(decodedResponseBody, new TypeReference<>() {});
+    } catch (Exception e) {
+      log.error("[CODEF] 응답 JSON 파싱 실패 - body: {}", decodedResponseBody, e);
+      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
+    }
+  }
+
+  private CodefChildRegisterResponse toChildRegisterResponse(Map<String, Object> response) {
+    Object resultObject = response.get("result");
+
+    if (!(resultObject instanceof Map<?, ?> result)) {
+      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
+    }
+
+    Object dataObject = response.get("data");
+
+    Map<?, ?> data = null;
+    if (dataObject instanceof Map<?, ?> dataMap) {
+      data = dataMap;
+    }
+
+    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
+
+    Map<String, Object> twoWayInfo = null;
+    if (data != null && Boolean.TRUE.equals(continue2Way)) {
+      twoWayInfo = new HashMap<>();
+      twoWayInfo.put("jobIndex", data.get("jobIndex"));
+      twoWayInfo.put("threadIndex", data.get("threadIndex"));
+      twoWayInfo.put("jti", data.get("jti"));
+      twoWayInfo.put("twoWayTimestamp", data.get("twoWayTimestamp"));
+    }
+
+    return CodefChildRegisterResponse.builder()
+        .resultCode(String.valueOf(result.get("code")))
+        .resultMessage(String.valueOf(result.get("message")))
+        .continue2Way(continue2Way)
+        .method(data != null ? String.valueOf(data.get("method")) : null)
+        .twoWayInfo(twoWayInfo)
+        .resRegistrationStatus(
+            data != null ? String.valueOf(data.get("resRegistrationStatus")) : null)
+        .resResultDesc(data != null ? String.valueOf(data.get("resResultDesc")) : null)
+        .rawData(response)
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
@@ -1,0 +1,65 @@
+package com.springboot.iboribe.domain.codef.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegister2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegisterRequest;
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
+import com.springboot.iboribe.domain.codef.service.CodefService;
+import com.springboot.iboribe.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/codef")
+@Tag(name = "Codef", description = "CODEF 외부 API 연동")
+public class CodefController {
+
+  private final CodefService codefService;
+
+  @Operation(
+      summary = "[토큰 O] CODEF 자녀 등록 테스트",
+      description =
+          """
+          **Parameters**  \n
+          CODEF 건강iN 자녀 등록 요청값  \n
+
+          **Returns**  \n
+          CODEF 자녀 등록 API 응답 결과  \n
+          """)
+  @PostMapping("/children/register")
+  public ResponseEntity<BaseResponse<CodefChildRegisterResponse>> registerChild(
+      @Valid @RequestBody CodefChildRegisterRequest request) {
+
+    CodefChildRegisterResponse response = codefService.registerChild(request);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "CODEF 자녀 등록 성공", response));
+  }
+
+  @Operation(
+      summary = "[토큰 O] CODEF 자녀 등록 2차 요청",
+      description =
+          """
+          **Process**  \n
+          - 1차 요청 후 카카오/간편인증 완료  \n
+          - 1차 응답의 twoWayInfo 전달  \n
+          - simpleAuth=1 전달  \n
+
+          **Returns**  \n
+          CODEF 자녀 등록 최종 응답  \n
+          """)
+  @PostMapping("/children/register/2way")
+  public ResponseEntity<BaseResponse<CodefChildRegisterResponse>> registerChild2Way(
+      @Valid @RequestBody CodefChildRegister2WayRequest request) {
+
+    CodefChildRegisterResponse response = codefService.registerChild2Way(request);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "CODEF 자녀 등록 2차 요청 성공", response));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefChildRegister2WayRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefChildRegister2WayRequest.java
@@ -1,0 +1,58 @@
+package com.springboot.iboribe.domain.codef.dto.request;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "CodefChildRegister2WayRequest: CODEF 자녀 등록 2차 요청 DTO")
+public class CodefChildRegister2WayRequest {
+
+  @NotBlank(message = "기관코드는 필수입니다.")
+  @Schema(description = "기관코드", example = "0002")
+  private String organization;
+
+  @NotBlank(message = "로그인 구분은 필수입니다.")
+  @Schema(description = "로그인 구분, 간편인증은 5", example = "5")
+  private String loginType;
+
+  @NotBlank(message = "간편인증 로그인 구분은 필수입니다.")
+  @Schema(description = "1:카카오톡, 3:삼성패스, 4:KB모바일인증서, 5:통신사인증서, 10:NH인증서", example = "1")
+  private String loginTypeLevel;
+
+  @NotBlank(message = "사용자 이름은 필수입니다.")
+  @Schema(description = "보호자 이름", example = "김복남")
+  private String userName;
+
+  @NotBlank(message = "생년월일은 필수입니다.")
+  @Schema(description = "보호자 생년월일 YYYYMMDD", example = "19990101")
+  private String identity;
+
+  @NotBlank(message = "전화번호는 필수입니다.")
+  @Schema(description = "보호자 전화번호", example = "01012345678")
+  private String phoneNo;
+
+  @Schema(description = "통신사, loginTypeLevel=5일 때 필수", example = "0")
+  private String telecom;
+
+  @Schema(description = "요청 식별 아이디", example = "user1-uuid")
+  private String id;
+
+  @NotBlank(message = "간편인증 완료 여부는 필수입니다.")
+  @Schema(description = "간편인증 완료 여부, 1: 확인", example = "1")
+  private String simpleAuth;
+
+  @NotBlank(message = "자녀 이름은 필수입니다.")
+  @Schema(description = "등록할 영유아 이름", example = "김아기")
+  private String childName;
+
+  @NotNull(message = "추가 인증 정보는 필수입니다.")
+  @Schema(description = "1차 요청 응답의 twoWayInfo")
+  private Map<String, Object> twoWayInfo;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefChildRegisterRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefChildRegisterRequest.java
@@ -1,0 +1,43 @@
+package com.springboot.iboribe.domain.codef.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "CodefChildRegisterRequest: CODEF 자녀 등록 요청 DTO")
+public class CodefChildRegisterRequest {
+
+  @NotBlank(message = "기관코드는 필수입니다.")
+  @Schema(description = "기관코드", example = "0002")
+  private String organization;
+
+  @NotBlank(message = "로그인 구분은 필수입니다.")
+  @Schema(description = "로그인 구분, 간편인증은 5", example = "5")
+  private String loginType;
+
+  @NotBlank(message = "간편인증 로그인 구분은 필수입니다.")
+  @Schema(description = "1:카카오톡, 3:삼성패스, 4:KB모바일인증서, 5:통신사인증서, 10:NH인증서", example = "1")
+  private String loginTypeLevel;
+
+  @NotBlank(message = "사용자 이름은 필수입니다.")
+  @Schema(description = "보호자 이름", example = "김서연")
+  private String userName;
+
+  @NotBlank(message = "생년월일은 필수입니다.")
+  @Schema(description = "보호자 생년월일 YYYYMMDD", example = "19990101")
+  private String identity;
+
+  @Schema(description = "통신사, loginTypeLevel=5일 때 필수", example = "0")
+  private String telecom;
+
+  @NotBlank(message = "전화번호는 필수입니다.")
+  @Schema(description = "보호자 전화번호", example = "01012345678")
+  private String phoneNo;
+
+  @Schema(description = "다건 요청/세션 식별값", example = "user1-uuid")
+  private String id;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefChildRegisterResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefChildRegisterResponse.java
@@ -1,0 +1,37 @@
+package com.springboot.iboribe.domain.codef.dto.response;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "CodefChildRegisterResponse: CODEF 자녀 등록 응답 DTO")
+public class CodefChildRegisterResponse {
+
+  @Schema(description = "CODEF 결과 코드", example = "CF-00000")
+  private String resultCode;
+
+  @Schema(description = "CODEF 결과 메시지", example = "성공")
+  private String resultMessage;
+
+  @Schema(description = "추가 인증 필요 여부", example = "true")
+  private Boolean continue2Way;
+
+  @Schema(description = "추가 인증 방식", example = "simpleAuth")
+  private String method;
+
+  @Schema(description = "2차 요청에 필요한 추가 인증 정보")
+  private Map<String, Object> twoWayInfo;
+
+  @Schema(description = "등록 여부, 0:false / 1:true", example = "1")
+  private String resRegistrationStatus;
+
+  @Schema(description = "등록 실패 사유", example = "")
+  private String resResultDesc;
+
+  @Schema(description = "CODEF 원본 응답 데이터")
+  private Map<String, Object> rawData;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/exception/CodefErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/exception/CodefErrorCode.java
@@ -1,0 +1,27 @@
+package com.springboot.iboribe.domain.codef.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.springboot.iboribe.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CodefErrorCode implements BaseErrorCode {
+  CODEF_BAD_REQUEST("CODEF4001", "CODEF 요청값이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  CODEF_UNAUTHORIZED("CODEF4011", "CODEF 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+
+  CODEF_FORBIDDEN("CODEF4031", "CODEF API 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+  CODEF_INVALID_RESPONSE("CODEF5021", "CODEF 응답 형식이 올바르지 않습니다.", HttpStatus.BAD_GATEWAY),
+  CODEF_EMPTY_RESPONSE("CODEF5022", "CODEF 응답 데이터가 비어 있습니다.", HttpStatus.BAD_GATEWAY),
+
+  CODEF_API_TIMEOUT("CODEF5041", "CODEF API 응답 시간이 초과되었습니다.", HttpStatus.GATEWAY_TIMEOUT),
+  CODEF_API_REQUEST_FAIL("CODEF5023", "CODEF API 호출에 실패했습니다.", HttpStatus.BAD_GATEWAY);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/service/CodefService.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/service/CodefService.java
@@ -1,0 +1,28 @@
+package com.springboot.iboribe.domain.codef.service;
+
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegister2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegisterRequest;
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
+
+public interface CodefService {
+
+  /**
+   * CODEF 자녀 등록 (1차 요청) <br>
+   * - 간편인증 / 인증서 기반 자녀 등록 요청 <br>
+   * - 추가 인증 필요 시 continue2Way = true 반환 <br>
+   *
+   * @param request CODEF 자녀 등록 요청 DTO
+   * @return CODEF 자녀 등록 응답
+   */
+  CodefChildRegisterResponse registerChild(CodefChildRegisterRequest request);
+
+  /**
+   * CODEF 자녀 등록 (2차 요청 - 추가 인증) <br>
+   * - 1차 요청에서 continue2Way = true 인 경우 호출 <br>
+   * - simpleAuth, childName, twoWayInfo 포함하여 최종 등록 수행 <br>
+   *
+   * @param request CODEF 자녀 등록 2차 요청 DTO
+   * @return CODEF 자녀 등록 최종 결과
+   */
+  CodefChildRegisterResponse registerChild2Way(CodefChildRegister2WayRequest request);
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/service/CodefServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/service/CodefServiceImpl.java
@@ -1,0 +1,46 @@
+package com.springboot.iboribe.domain.codef.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.codef.client.CodefClient;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegister2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegisterRequest;
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CodefServiceImpl implements CodefService {
+
+  private final CodefClient codefClient;
+
+  /** 1차 요청 */
+  @Override
+  public CodefChildRegisterResponse registerChild(CodefChildRegisterRequest request) {
+    log.info("[CODEF] 자녀 등록 API 호출 시작 - userName: {}", request.getUserName());
+
+    CodefChildRegisterResponse response = codefClient.registerChild(request);
+
+    log.info("[CODEF] 자녀 등록 API 호출 완료 - resultCode: {}", response.getResultCode());
+
+    return response;
+  }
+
+  /** 2차 요청 (간편인증 이후) */
+  @Override
+  @Transactional
+  public CodefChildRegisterResponse registerChild2Way(CodefChildRegister2WayRequest request) {
+    log.info("[CODEF] 자녀 등록 2차 요청 시작 - childName: {}", request.getChildName());
+
+    CodefChildRegisterResponse response = codefClient.registerChild2Way(request);
+
+    log.info("[CODEF] 자녀 등록 2차 요청 완료 - resultCode: {}", response.getResultCode());
+
+    return response;
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #9 


## 📝 요약(Summary)
CODEF 외부 API 연동을 위한 자녀 등록 기능 구현

- CODEF API 호출을 위한 client, service, controller 구조 설계 및 구현
- 자녀 등록 1차 요청 (간편인증 요청) 기능 구현
- 자녀 등록 2차 요청 (simpleAuth 기반 추가 인증 처리) 기능 구현
- CODEF 응답 구조(result/data)를 기반으로 DTO 설계
- 2Way 인증 흐름 (continue2Way, twoWayInfo) 처리 로직 구현
- URL 인코딩된 응답을 디코딩 후 JSON 파싱하도록 개선
- CODEF 전용 예외 처리 및 에러 코드 정의


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
