### PR TITLE
✨ Feat: 혼잡도 예측 API 및 예상검색어 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/district/controller/DistrictController.java
+++ b/src/main/java/com/springboot/iboribe/domain/district/controller/DistrictController.java
@@ -1,0 +1,44 @@
+package com.springboot.iboribe.domain.district.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.springboot.iboribe.domain.district.dto.response.DistrictResponse;
+import com.springboot.iboribe.domain.district.service.DistrictService;
+import com.springboot.iboribe.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/district")
+@Tag(name = "District", description = "동 검색 API")
+public class DistrictController {
+
+  private final DistrictService districtService;
+
+  @Operation(
+      summary = "[토큰 X] 동 키워드 검색",
+      description =
+          """
+          **Parameters**  \n
+          keyword: 검색할 동 키워드 (예: 잠실)  \n
+
+          **Returns**  \n
+          gu: 구 이름  \n
+          dong: 동 이름  \n
+          displayName: 표시 이름 (예: 서울시 송파구 잠실동)  \n
+          """)
+  @GetMapping("/search")
+  public ResponseEntity<BaseResponse<List<DistrictResponse>>> search(@RequestParam String keyword) {
+
+    return ResponseEntity.ok(BaseResponse.success(districtService.search(keyword)));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/district/dto/response/DistrictResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/district/dto/response/DistrictResponse.java
@@ -1,0 +1,24 @@
+package com.springboot.iboribe.domain.district.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(title = "DistrictResponse: 동 검색 응답 DTO")
+public class DistrictResponse {
+
+  @Schema(description = "구 이름", example = "송파구")
+  private final String gu;
+
+  @Schema(description = "동 이름", example = "잠실동")
+  private final String dong;
+
+  @Schema(description = "표시 이름", example = "서울시 송파구 잠실동")
+  private final String displayName;
+
+  public DistrictResponse(String gu, String dong) {
+    this.gu = gu;
+    this.dong = dong;
+    this.displayName = "서울시 " + gu + " " + dong;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/district/service/DistrictService.java
+++ b/src/main/java/com/springboot/iboribe/domain/district/service/DistrictService.java
@@ -1,0 +1,23 @@
+package com.springboot.iboribe.domain.district.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.district.dto.response.DistrictResponse;
+import com.springboot.iboribe.domain.hospital.repository.HospitalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DistrictService {
+
+  private final HospitalRepository hospitalRepository;
+
+  public List<DistrictResponse> search(String keyword) {
+    return hospitalRepository.searchDistricts(keyword);
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/hospital/repository/HospitalRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/hospital/repository/HospitalRepository.java
@@ -6,10 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.springboot.iboribe.domain.district.dto.response.DistrictResponse;
 import com.springboot.iboribe.domain.hospital.entity.Hospital;
 
 public interface HospitalRepository extends JpaRepository<Hospital, Long> {
-  // nightOnly = false (야간진료 필터 OFF), nightOnly = true (야간진료 필터 ON)
+
   @Query(
       value =
           """
@@ -31,4 +32,10 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
       @Param("lng") double lng,
       @Param("radius") double radius,
       @Param("nightOnly") boolean nightOnly);
+
+  @Query(
+      "SELECT new com.springboot.iboribe.domain.district.dto.response.DistrictResponse(h.gu, h.dong) "
+          + "FROM Hospital h WHERE h.gu LIKE %:keyword% OR h.dong LIKE %:keyword% "
+          + "GROUP BY h.gu, h.dong ORDER BY h.gu, h.dong")
+  List<DistrictResponse> searchDistricts(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/springboot/iboribe/domain/predict/client/PredictClient.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/client/PredictClient.java
@@ -1,0 +1,88 @@
+package com.springboot.iboribe.domain.predict.client;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.springboot.iboribe.domain.predict.entity.CongestionLevel;
+import com.springboot.iboribe.domain.predict.exception.PredictErrorCode;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class PredictClient {
+
+  private static final String PREDICT_URI = "/predict/dong";
+  private static final Map<DayOfWeek, String> DAY_OF_WEEK_MAP =
+      Map.of(
+          DayOfWeek.MONDAY, "월요일",
+          DayOfWeek.TUESDAY, "화요일",
+          DayOfWeek.WEDNESDAY, "수요일",
+          DayOfWeek.THURSDAY, "목요일",
+          DayOfWeek.FRIDAY, "금요일",
+          DayOfWeek.SATURDAY, "토요일",
+          DayOfWeek.SUNDAY, "일요일");
+
+  private final WebClient webClient;
+
+  public PredictClient(WebClient.Builder webClientBuilder) {
+    this.webClient = webClientBuilder.baseUrl("https://ibori.site").build();
+  }
+
+  // 월, 요일은 서울 기준으로 자동 세팅
+  public ExternalPredictResponse predict(String dong) {
+    LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    int month = today.getMonthValue();
+    String dayOfWeek = DAY_OF_WEEK_MAP.get(today.getDayOfWeek());
+
+    Map<String, Object> body =
+        Map.of(
+            "dong", dong,
+            "month", month,
+            "day_of_week", dayOfWeek);
+
+    return webClient
+        .post()
+        .uri(PREDICT_URI)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(ExternalPredictResponse.class)
+        .timeout(Duration.ofSeconds(10))
+        .onErrorMap(
+            TimeoutException.class, e -> new CustomException(PredictErrorCode.PREDICT_API_TIMEOUT))
+        .onErrorMap(
+            WebClientResponseException.class,
+            e -> {
+              log.error(
+                  "[Predict] 외부 API 호출 실패 - status: {}, body: {}",
+                  e.getStatusCode(),
+                  e.getResponseBodyAsString());
+              return new CustomException(PredictErrorCode.PREDICT_API_ERROR);
+            })
+        .block();
+  }
+
+  @Getter
+  @NoArgsConstructor
+  public static class ExternalPredictResponse {
+    private String dong;
+    private String gu;
+
+    @JsonProperty("congestion_level")
+    private CongestionLevel congestionLevel;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/controller/PredictController.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/controller/PredictController.java
@@ -1,0 +1,49 @@
+package com.springboot.iboribe.domain.predict.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.springboot.iboribe.domain.predict.dto.request.PredictRequest;
+import com.springboot.iboribe.domain.predict.dto.response.PredictResponse;
+import com.springboot.iboribe.domain.predict.service.PredictService;
+import com.springboot.iboribe.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/predict")
+@Tag(name = "Predict", description = "혼잡도 예측 API")
+public class PredictController {
+
+  private final PredictService predictService;
+
+  @Operation(
+      summary = "[토큰 X] 소아청소년과 혼잡도 예측",
+      description =
+          """
+          **Parameters**  \n
+          dong: 동 이름 (예: 역삼동)  \n
+
+          **Note**  \n
+          월과 요일은 서버의 오늘 날짜 기준으로 자동 적용됩니다.  \n
+
+          **Returns**  \n
+          gu: 구 이름  \n
+          dong: 동 이름  \n
+          congestionLevel: 혼잡도 (여유 / 보통 / 혼잡 / 매우혼잡)  \n
+          """)
+  @PostMapping("/dong")
+  public ResponseEntity<BaseResponse<PredictResponse>> predict(
+      @Valid @RequestBody PredictRequest request) {
+
+    return ResponseEntity.ok(BaseResponse.success(predictService.predict(request)));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/dto/request/PredictRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/dto/request/PredictRequest.java
@@ -1,0 +1,17 @@
+package com.springboot.iboribe.domain.predict.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(title = "PredictRequest: 혼잡도 예측 요청 DTO")
+public class PredictRequest {
+
+  @NotBlank
+  @Schema(description = "동 이름", example = "역삼동")
+  private String dong;
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/dto/response/PredictResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/dto/response/PredictResponse.java
@@ -1,0 +1,22 @@
+package com.springboot.iboribe.domain.predict.dto.response;
+
+import com.springboot.iboribe.domain.predict.entity.CongestionLevel;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "PredictResponse: 혼잡도 예측 응답 DTO")
+public class PredictResponse {
+
+  @Schema(description = "구 이름", example = "강남구")
+  private String gu;
+
+  @Schema(description = "동 이름", example = "역삼동")
+  private String dong;
+
+  @Schema(description = "혼잡도", example = "보통")
+  private CongestionLevel congestionLevel;
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/entity/CongestionLevel.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/entity/CongestionLevel.java
@@ -1,0 +1,20 @@
+package com.springboot.iboribe.domain.predict.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum CongestionLevel {
+  여유,
+  보통,
+  혼잡,
+  매우혼잡;
+
+  @JsonCreator
+  public static CongestionLevel from(String value) {
+    for (CongestionLevel level : values()) {
+      if (level.name().equals(value)) {
+        return level;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/exception/PredictErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/exception/PredictErrorCode.java
@@ -1,0 +1,19 @@
+package com.springboot.iboribe.domain.predict.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.springboot.iboribe.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PredictErrorCode implements BaseErrorCode {
+  PREDICT_API_TIMEOUT("PREDICT5031", "예측 서버 응답 시간이 초과되었습니다.", HttpStatus.GATEWAY_TIMEOUT),
+  PREDICT_API_ERROR("PREDICT5021", "예측 서버 호출 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/springboot/iboribe/domain/predict/service/PredictService.java
+++ b/src/main/java/com/springboot/iboribe/domain/predict/service/PredictService.java
@@ -1,0 +1,27 @@
+package com.springboot.iboribe.domain.predict.service;
+
+import org.springframework.stereotype.Service;
+
+import com.springboot.iboribe.domain.predict.client.PredictClient;
+import com.springboot.iboribe.domain.predict.client.PredictClient.ExternalPredictResponse;
+import com.springboot.iboribe.domain.predict.dto.request.PredictRequest;
+import com.springboot.iboribe.domain.predict.dto.response.PredictResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PredictService {
+
+  private final PredictClient predictClient;
+
+  public PredictResponse predict(PredictRequest request) {
+    ExternalPredictResponse external = predictClient.predict(request.getDong());
+
+    return PredictResponse.builder()
+        .gu(external.getGu())
+        .dong(external.getDong())
+        .congestionLevel(external.getCongestionLevel())
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/api/auth/**",
                         "/api/hospital/**",
-                        "/api/predict/**")
+                        "/api/predict/**",
+                        "/api/district/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                         "/swagger-ui.html",
                         "/v3/api-docs/**",
                         "/api/auth/**",
-                        "/api/hospital/**")
+                        "/api/hospital/**",
+                        "/api/predict/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #18 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #{Issue_number}를 적어주세요. -->

## 📝 요약(Summary)
- 외부 혼잡도 예측 서버(https://ibori.site/predict/dong)를 호출하는 프록시 API 구현        
- 사용자는 동 이름만 입력하면 서버에서 오늘 날짜(월, 요일) 자동 적용                       
- 응답으로 구, 동, 혼잡도(여유/보통/혼잡/매우혼잡 Enum) 반환                           
- 구/동 키워드 검색 API 구현 (구 이름 또는 동 이름 모두 검색 가능) 
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
