### PR TITLE
♻️ Refactor: 가족고유번호 기반 회원가입 구조 적용

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/dto/request/SignUpRequest.java
@@ -1,6 +1,7 @@
 package com.springboot.iboribe.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -28,4 +29,16 @@ public class SignUpRequest {
       message = "비밀번호는 8~20자이며, 영문/숫자/특수문자를 모두 포함해야 합니다.")
   @Schema(description = "사용자 비밀번호", example = "BabyCare123!")
   private String password;
+
+  @NotBlank(message = "가족고유번호는 필수입니다.")
+  @Size(min = 8, max = 20, message = "가족고유번호는 8자 이상 20자 이하로 입력해야 합니다.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*[!@#$%^&*()_+=\\-{}\\[\\]:;\"'<>,.?/]).{8,20}$",
+      message = "가족고유번호는 8자 이상이며 영문자와 특수문자를 포함해야 합니다.")
+  @Schema(description = "가족고유번호", example = "Family!123")
+  private String familyCode;
+
+  @NotNull(message = "가족 첫 가입자 여부는 필수입니다.")
+  @Schema(description = "가족 중 첫 가입자 여부", example = "true")
+  private Boolean firstFamilyMember;
 }

--- a/src/main/java/com/springboot/iboribe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/exception/AuthErrorCode.java
@@ -13,11 +13,13 @@ public enum AuthErrorCode implements BaseErrorCode {
   ALREADY_EXIST_USERNAME("AUTH4001", "이미 사용 중인 아이디입니다.", HttpStatus.BAD_REQUEST),
   LOGIN_FAIL("AUTH4002", "아이디 또는 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
   INVALID_INPUT_FORMAT("AUTH4003", "아이디 또는 비밀번호 형식이 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_EXIST_FAMILY_CODE("AUTH4004", "이미 사용 중인 가족고유번호입니다.", HttpStatus.BAD_REQUEST),
 
   REFRESH_TOKEN_REQUIRED("AUTH4011", "리프레시 토큰이 필요합니다.", HttpStatus.UNAUTHORIZED),
   INVALID_REFRESH_TOKEN("AUTH4012", "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
 
-  USER_NOT_FOUND("AUTH4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+  USER_NOT_FOUND("AUTH4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  FAMILY_NOT_FOUND("AUTH4042", "존재하지 않는 가족고유번호입니다.", HttpStatus.NOT_FOUND);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/springboot/iboribe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/service/AuthServiceImpl.java
@@ -8,6 +8,8 @@ import com.springboot.iboribe.domain.auth.dto.request.LoginRequest;
 import com.springboot.iboribe.domain.auth.dto.request.SignUpRequest;
 import com.springboot.iboribe.domain.auth.dto.response.TokenResponse;
 import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.repository.FamilyRepository;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
 import com.springboot.iboribe.global.exception.CustomException;
@@ -26,12 +28,27 @@ public class AuthServiceImpl implements AuthService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
+  private final FamilyRepository familyRepository;
 
   @Override
   public void signUp(SignUpRequest request) {
     if (userRepository.existsByUsername(request.getUsername())) {
-      log.warn("[Auth] 이미 사용 중인 아이디로 회원가입 시도 - username: {}", request.getUsername());
       throw new CustomException(AuthErrorCode.ALREADY_EXIST_USERNAME);
+    }
+
+    Family family;
+
+    if (request.getFirstFamilyMember()) {
+      if (familyRepository.existsByFamilyCode(request.getFamilyCode())) {
+        throw new CustomException(AuthErrorCode.ALREADY_EXIST_FAMILY_CODE);
+      }
+
+      family = familyRepository.save(Family.builder().familyCode(request.getFamilyCode()).build());
+    } else {
+      family =
+          familyRepository
+              .findByFamilyCode(request.getFamilyCode())
+              .orElseThrow(() -> new CustomException(AuthErrorCode.FAMILY_NOT_FOUND));
     }
 
     User user =
@@ -39,14 +56,10 @@ public class AuthServiceImpl implements AuthService {
             .name(request.getName())
             .username(request.getUsername())
             .password(passwordEncoder.encode(request.getPassword()))
+            .family(family)
             .build();
 
-    User savedUser = userRepository.save(user);
-
-    log.info(
-        "[Auth] 신규 사용자 회원가입 성공 - userId: {}, username: {}",
-        savedUser.getId(),
-        savedUser.getUsername());
+    userRepository.save(user);
   }
 
   @Override

--- a/src/main/java/com/springboot/iboribe/domain/family/entity/Family.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/entity/Family.java
@@ -1,0 +1,30 @@
+package com.springboot.iboribe.domain.family.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "families")
+public class Family {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 20)
+  private String familyCode;
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/repository/FamilyRepository.java
@@ -1,0 +1,14 @@
+package com.springboot.iboribe.domain.family.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.springboot.iboribe.domain.family.entity.Family;
+
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+
+  boolean existsByFamilyCode(String familyCode);
+
+  Optional<Family> findByFamilyCode(String familyCode);
+}

--- a/src/main/java/com/springboot/iboribe/domain/user/entity/User.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package com.springboot.iboribe.domain.user.entity;
 
 import jakarta.persistence.*;
 
+import com.springboot.iboribe.domain.family.entity.Family;
+
 import lombok.*;
 
 @Entity
@@ -24,4 +26,8 @@ public class User {
 
   @Column(nullable = false)
   private String password;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "family_id", nullable = false)
+  private Family family;
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #40 

## 📝 요약(Summary)
기존 사용자 단독 회원가입 구조에서 가족 단위 가입 구조를 지원할 수 있도록 회원가입 로직 리팩토링

첫 가입자는 가족고유번호를 직접 등록하여 가족 그룹을 생성하고,
이후 가입자는 기존 가족고유번호를 입력하여 동일한 가족 그룹에 소속될 수 있도록 구현

또한 가족고유번호 중복 검증 및 존재 여부 검증 로직을 추가하여
유효하지 않은 가족고유번호 사용을 방지하도록 수정

주요 변경 사항

* Family 엔티티 및 Repository 추가
* User와 Family 연관관계 추가
* 회원가입 요청 DTO 수정
* 가족고유번호 기반 회원가입 로직 추가
* 가족고유번호 중복 검증 로직 추가
* 존재하지 않는 가족고유번호 예외 처리 추가
* 관련 Auth 예외 코드 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
