### PR TITLE
:sparkles: Feat: 가족 구성원 및 의료 기록 조회 기능 구현

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/controller/AuthController.java
@@ -30,6 +30,31 @@ public class AuthController {
   private final JwtProvider jwtProvider;
   private final JwtCookieWriter jwtCookieWriter;
 
+  @PostMapping("/demo-login")
+  @Operation(
+      summary = "[토큰 X] 데모 계정 로그인",
+      description =
+          """
+          **Purpose**  \n
+          - 공모전 심사용 데모 계정 로그인  \n
+          - 별도 회원가입 없이 미리 등록된 사용자/아이/진료 기록 데이터 확인 가능  \n
+
+          **Process**  \n
+          - 서버에 등록된 demo_parent 계정으로 로그인  \n
+          - ACCESS_TOKEN, REFRESH_TOKEN 쿠키 저장  \n
+
+          **Returns**  \n
+          userId, name, username  \n
+          accessToken, refreshToken  \n
+          """)
+  public ResponseEntity<BaseResponse<TokenResponse>> demoLogin() {
+    TokenResponse response = authService.demoLogin();
+
+    return ResponseEntity.ok()
+        .headers(createTokenHeaders(response))
+        .body(BaseResponse.success(200, "데모 계정 로그인 성공", response));
+  }
+
   @Operation(
       summary = "[토큰 X] 회원가입",
       description =

--- a/src/main/java/com/springboot/iboribe/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/dto/request/SignUpRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,4 +43,8 @@ public class SignUpRequest {
   @NotNull(message = "가족 첫 가입자 여부는 필수입니다.")
   @Schema(description = "가족 중 첫 가입자 여부", example = "true")
   private Boolean firstFamilyMember;
+
+  @NotNull(message = "가족 구성원 역할은 필수입니다.")
+  @Schema(description = "가족 구성원 역할", example = "MOTHER")
+  private FamilyRole familyRole;
 }

--- a/src/main/java/com/springboot/iboribe/domain/auth/dto/request/TestLoginRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/dto/request/TestLoginRequest.java
@@ -1,0 +1,12 @@
+package com.springboot.iboribe.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Getter;
+
+@Getter
+public class TestLoginRequest {
+
+  @NotBlank(message = "아이디는 필수입니다.")
+  private String username;
+}

--- a/src/main/java/com/springboot/iboribe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/exception/AuthErrorCode.java
@@ -17,6 +17,7 @@ public enum AuthErrorCode implements BaseErrorCode {
 
   REFRESH_TOKEN_REQUIRED("AUTH4011", "리프레시 토큰이 필요합니다.", HttpStatus.UNAUTHORIZED),
   INVALID_REFRESH_TOKEN("AUTH4012", "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
+  AUTHENTICATION_REQUIRED("AUTH4013", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
 
   USER_NOT_FOUND("AUTH4041", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   FAMILY_NOT_FOUND("AUTH4042", "존재하지 않는 가족고유번호입니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/com/springboot/iboribe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/service/AuthService.java
@@ -6,6 +6,9 @@ import com.springboot.iboribe.domain.auth.dto.response.TokenResponse;
 
 public interface AuthService {
 
+  /** 데모 계정으로 로그인 */
+  TokenResponse demoLogin();
+
   /** 회원가입 */
   void signUp(SignUpRequest request);
 

--- a/src/main/java/com/springboot/iboribe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/service/AuthServiceImpl.java
@@ -29,6 +29,20 @@ public class AuthServiceImpl implements AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtProvider jwtProvider;
   private final FamilyRepository familyRepository;
+  private static final String DEMO_USERNAME = "mom_jiyoon";
+
+  @Override
+  @Transactional(readOnly = true)
+  public TokenResponse demoLogin() {
+    User user =
+        userRepository
+            .findByUsername(DEMO_USERNAME)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+    log.info("[Auth] 데모 계정 로그인 성공 - userId: {}, username: {}", user.getId(), user.getUsername());
+
+    return createTokenResponse(user);
+  }
 
   @Override
   public void signUp(SignUpRequest request) {
@@ -57,6 +71,7 @@ public class AuthServiceImpl implements AuthService {
             .username(request.getUsername())
             .password(passwordEncoder.encode(request.getPassword()))
             .family(family)
+            .familyRole(request.getFamilyRole())
             .build();
 
     userRepository.save(user);

--- a/src/main/java/com/springboot/iboribe/domain/child/entity/Child.java
+++ b/src/main/java/com/springboot/iboribe/domain/child/entity/Child.java
@@ -1,0 +1,34 @@
+package com.springboot.iboribe.domain.child.entity;
+
+import jakarta.persistence.*;
+
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
+
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+    name = "children",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"family_id", "name"})})
+public class Child {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 30)
+  private String name;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "family_id", nullable = false)
+  private Family family;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private FamilyRole familyRole;
+}

--- a/src/main/java/com/springboot/iboribe/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/child/repository/ChildRepository.java
@@ -1,0 +1,16 @@
+package com.springboot.iboribe.domain.child.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.family.entity.Family;
+
+public interface ChildRepository extends JpaRepository<Child, Long> {
+
+  Optional<Child> findByFamilyAndName(Family family, String name);
+
+  List<Child> findAllByFamily(Family family);
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/client/CodefClient.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/client/CodefClient.java
@@ -3,9 +3,6 @@ package com.springboot.iboribe.domain.codef.client;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
@@ -25,11 +22,10 @@ import com.springboot.iboribe.domain.codef.dto.response.CodefChildListResponse;
 import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
 import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
 import com.springboot.iboribe.domain.codef.exception.CodefErrorCode;
+import com.springboot.iboribe.domain.codef.mapper.CodefRequestBodyMapper;
+import com.springboot.iboribe.domain.codef.mapper.CodefResponseMapper;
 import com.springboot.iboribe.global.exception.CustomException;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @Component
 public class CodefClient {
 
@@ -42,73 +38,54 @@ public class CodefClient {
 
   private final WebClient webClient;
   private final ObjectMapper objectMapper;
+  private final CodefResponseMapper responseMapper;
+  private final CodefRequestBodyMapper requestBodyMapper;
   private final String accessToken;
 
   public CodefClient(
       WebClient.Builder webClientBuilder,
       ObjectMapper objectMapper,
+      CodefResponseMapper responseMapper,
+      CodefRequestBodyMapper requestBodyMapper,
       @Value("${codef.base-url}") String baseUrl,
       @Value("${codef.access-token}") String accessToken) {
+
     this.webClient = webClientBuilder.baseUrl(baseUrl).build();
     this.objectMapper = objectMapper;
+    this.responseMapper = responseMapper;
+    this.requestBodyMapper = requestBodyMapper;
     this.accessToken = accessToken;
   }
 
   public CodefChildRegisterResponse registerChild(CodefChildAuthRequest request) {
-    String responseBody = callCodef(CHILD_REGISTER_URI, request);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toChildRegisterResponse(response);
+    return responseMapper.toChildRegisterResponse(
+        parseResponse(callCodef(CHILD_REGISTER_URI, request)));
   }
 
   public CodefChildRegisterResponse registerChild2Way(CodefChildRegister2WayRequest request) {
-    Map<String, Object> body = new HashMap<>();
-
-    body.put("organization", request.getOrganization());
-    body.put("loginType", request.getLoginType());
-    body.put("loginTypeLevel", request.getLoginTypeLevel());
-    body.put("userName", request.getUserName());
-    body.put("identity", request.getIdentity());
-    body.put("phoneNo", request.getPhoneNo());
-    body.put("telecom", request.getTelecom());
-    body.put("id", request.getId());
-    body.put("simpleAuth", request.getSimpleAuth());
-    body.put("childName", request.getChildName());
-    body.put("is2Way", true);
-    body.put("twoWayInfo", request.getTwoWayInfo());
-
-    String responseBody = callCodef(CHILD_REGISTER_URI, body);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toChildRegisterResponse(response);
+    return responseMapper.toChildRegisterResponse(
+        parseResponse(
+            callCodef(CHILD_REGISTER_URI, requestBodyMapper.toChildRegister2WayBody(request))));
   }
 
   public CodefChildListResponse getChildList(CodefChildAuthRequest request) {
-    String responseBody = callCodef(CHILD_LIST_URI, request);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toChildListResponse(response);
+    return responseMapper.toChildListResponse(parseResponse(callCodef(CHILD_LIST_URI, request)));
   }
 
   public CodefChildListResponse getChildList2Way(CodefChildList2WayRequest request) {
-    Map<String, Object> body = new HashMap<>();
+    return responseMapper.toChildListResponse(
+        parseResponse(callCodef(CHILD_LIST_URI, requestBodyMapper.toChildList2WayBody(request))));
+  }
 
-    body.put("organization", request.getOrganization());
-    body.put("loginType", request.getLoginType());
-    body.put("loginTypeLevel", request.getLoginTypeLevel());
-    body.put("userName", request.getUserName());
-    body.put("identity", request.getIdentity());
-    body.put("phoneNo", request.getPhoneNo());
-    body.put("telecom", request.getTelecom());
-    body.put("id", request.getId());
-    body.put("simpleAuth", request.getSimpleAuth());
-    body.put("is2Way", true);
-    body.put("twoWayInfo", request.getTwoWayInfo());
+  public CodefTreatmentResponse getTreatmentInfo(CodefTreatmentRequest request) {
+    return responseMapper.toTreatmentResponse(
+        parseResponse(callCodef(TREATMENT_INFO_URI, request)));
+  }
 
-    String responseBody = callCodef(CHILD_LIST_URI, body);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toChildListResponse(response);
+  public CodefTreatmentResponse getTreatmentInfo2Way(CodefTreatment2WayRequest request) {
+    return responseMapper.toTreatmentResponse(
+        parseResponse(
+            callCodef(TREATMENT_INFO_URI, requestBodyMapper.toTreatment2WayBody(request))));
   }
 
   private String callCodef(String uri, Object requestBody) {
@@ -127,6 +104,7 @@ public class CodefClient {
   }
 
   private Map<String, Object> parseResponse(String responseBody) {
+
     if (responseBody == null) {
       throw new CustomException(CodefErrorCode.CODEF_EMPTY_RESPONSE);
     }
@@ -136,197 +114,7 @@ public class CodefClient {
     try {
       return objectMapper.readValue(decodedResponseBody, new TypeReference<>() {});
     } catch (Exception e) {
-      log.error("[CODEF] 응답 JSON 파싱 실패 - body: {}", decodedResponseBody, e);
       throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
     }
-  }
-
-  private CodefChildRegisterResponse toChildRegisterResponse(Map<String, Object> response) {
-    Object resultObject = response.get("result");
-
-    if (!(resultObject instanceof Map<?, ?> result)) {
-      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
-    }
-
-    Object dataObject = response.get("data");
-
-    Map<?, ?> data = null;
-    if (dataObject instanceof Map<?, ?> dataMap) {
-      data = dataMap;
-    }
-
-    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
-    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
-
-    return CodefChildRegisterResponse.builder()
-        .resultCode(String.valueOf(result.get("code")))
-        .resultMessage(String.valueOf(result.get("message")))
-        .continue2Way(continue2Way)
-        .method(data != null ? String.valueOf(data.get("method")) : null)
-        .twoWayInfo(twoWayInfo)
-        .resRegistrationStatus(
-            data != null ? String.valueOf(data.get("resRegistrationStatus")) : null)
-        .resResultDesc(data != null ? String.valueOf(data.get("resResultDesc")) : null)
-        .rawData(response)
-        .build();
-  }
-
-  private CodefChildListResponse toChildListResponse(Map<String, Object> response) {
-    Object resultObject = response.get("result");
-
-    if (!(resultObject instanceof Map<?, ?> result)) {
-      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
-    }
-
-    Object dataObject = response.get("data");
-
-    Map<?, ?> data = null;
-    if (dataObject instanceof Map<?, ?> dataMap) {
-      data = dataMap;
-    }
-
-    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
-    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
-    List<Map<String, Object>> children = extractChildren(dataObject, continue2Way);
-
-    return CodefChildListResponse.builder()
-        .resultCode(String.valueOf(result.get("code")))
-        .resultMessage(String.valueOf(result.get("message")))
-        .continue2Way(continue2Way)
-        .method(data != null ? String.valueOf(data.get("method")) : null)
-        .twoWayInfo(twoWayInfo)
-        .children(children)
-        .rawData(response)
-        .build();
-  }
-
-  private Map<String, Object> extractTwoWayInfo(Map<?, ?> data, Boolean continue2Way) {
-    if (data == null || !Boolean.TRUE.equals(continue2Way)) {
-      return null;
-    }
-
-    Map<String, Object> twoWayInfo = new HashMap<>();
-    twoWayInfo.put("jobIndex", data.get("jobIndex"));
-    twoWayInfo.put("threadIndex", data.get("threadIndex"));
-    twoWayInfo.put("jti", data.get("jti"));
-    twoWayInfo.put("twoWayTimestamp", data.get("twoWayTimestamp"));
-
-    return twoWayInfo;
-  }
-
-  @SuppressWarnings("unchecked")
-  private List<Map<String, Object>> extractChildren(Object dataObject, Boolean continue2Way) {
-    if (Boolean.TRUE.equals(continue2Way) || dataObject == null) {
-      return null;
-    }
-
-    List<Map<String, Object>> children = new ArrayList<>();
-
-    if (dataObject instanceof List<?> list) {
-      for (Object item : list) {
-        if (item instanceof Map<?, ?> child) {
-          children.add((Map<String, Object>) child);
-        }
-      }
-      return children;
-    }
-
-    if (dataObject instanceof Map<?, ?> child) {
-      children.add((Map<String, Object>) child);
-    }
-
-    return children;
-  }
-
-  public CodefTreatmentResponse getTreatmentInfo(CodefTreatmentRequest request) {
-    String responseBody = callCodef(TREATMENT_INFO_URI, request);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toTreatmentResponse(response);
-  }
-
-  public CodefTreatmentResponse getTreatmentInfo2Way(CodefTreatment2WayRequest request) {
-    Map<String, Object> body = new HashMap<>();
-
-    body.put("organization", request.getOrganization());
-    body.put("loginType", request.getLoginType());
-    body.put("loginTypeLevel", request.getLoginTypeLevel());
-    body.put("userName", request.getUserName());
-    body.put("identity", request.getIdentity());
-    body.put("phoneNo", request.getPhoneNo());
-    body.put("telecom", request.getTelecom());
-    body.put("id", request.getId());
-    body.put("startDate", request.getStartDate());
-    body.put("endDate", request.getEndDate());
-    body.put("type", request.getType());
-    body.put("drugImageYN", request.getDrugImageYN());
-    body.put("medicationDirectionYN", request.getMedicationDirectionYN());
-    body.put("detailYN", request.getDetailYN());
-    body.put("timeOut", request.getTimeOut());
-
-    body.put("simpleAuth", request.getSimpleAuth());
-    body.put("secureNo", request.getSecureNo());
-    body.put("secureNoRefresh", request.getSecureNoRefresh());
-    body.put("is2Way", true);
-    body.put("twoWayInfo", request.getTwoWayInfo());
-
-    String responseBody = callCodef(TREATMENT_INFO_URI, body);
-    Map<String, Object> response = parseResponse(responseBody);
-
-    return toTreatmentResponse(response);
-  }
-
-  @SuppressWarnings("unchecked")
-  private CodefTreatmentResponse toTreatmentResponse(Map<String, Object> response) {
-    Object resultObject = response.get("result");
-
-    if (!(resultObject instanceof Map<?, ?> result)) {
-      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
-    }
-
-    Object dataObject = response.get("data");
-
-    Map<?, ?> data = null;
-    if (dataObject instanceof Map<?, ?> dataMap) {
-      data = dataMap;
-    }
-
-    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
-    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
-    List<Map<String, Object>> treatments = extractTreatments(dataObject, continue2Way);
-
-    return CodefTreatmentResponse.builder()
-        .resultCode(String.valueOf(result.get("code")))
-        .resultMessage(String.valueOf(result.get("message")))
-        .continue2Way(continue2Way)
-        .method(data != null ? String.valueOf(data.get("method")) : null)
-        .twoWayInfo(twoWayInfo)
-        .treatments(treatments)
-        .rawData(response)
-        .build();
-  }
-
-  @SuppressWarnings("unchecked")
-  private List<Map<String, Object>> extractTreatments(Object dataObject, Boolean continue2Way) {
-    if (Boolean.TRUE.equals(continue2Way) || dataObject == null) {
-      return null;
-    }
-
-    List<Map<String, Object>> treatments = new ArrayList<>();
-
-    if (dataObject instanceof List<?> list) {
-      for (Object item : list) {
-        if (item instanceof Map<?, ?> treatment) {
-          treatments.add((Map<String, Object>) treatment);
-        }
-      }
-      return treatments;
-    }
-
-    if (dataObject instanceof Map<?, ?> treatment) {
-      treatments.add((Map<String, Object>) treatment);
-    }
-
-    return treatments;
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
@@ -3,6 +3,7 @@ package com.springboot.iboribe.domain.codef.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import com.springboot.iboribe.domain.codef.dto.request.CodefChildAuthRequest;
@@ -15,6 +16,7 @@ import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterRespon
 import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
 import com.springboot.iboribe.domain.codef.service.CodefService;
 import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,7 +31,7 @@ public class CodefController {
   private final CodefService codefService;
 
   @Operation(
-      summary = "[토큰 O] CODEF 자녀 등록 1차 요청",
+      summary = "[토큰 X] CODEF 자녀 등록 1차 요청",
       description =
           """
           **Description**  \n
@@ -60,7 +62,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 O] CODEF 자녀 등록 2차 요청",
+      summary = "[토큰 X] CODEF 자녀 등록 2차 요청",
       description =
           """
           **Description**  \n
@@ -86,7 +88,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 O] CODEF 자녀 목록 조회 1차 요청",
+      summary = "[토큰 X] CODEF 자녀 목록 조회 1차 요청",
       description =
           """
           **Description**  \n
@@ -117,7 +119,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 O] CODEF 자녀 목록 조회 2차 요청",
+      summary = "[토큰 X] CODEF 자녀 목록 조회 2차 요청",
       description =
           """
           **Description**  \n
@@ -142,7 +144,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 O] CODEF 진료 및 투약정보 조회 1차 요청",
+      summary = "[토큰 X] CODEF 진료 및 투약정보 조회 1차 요청",
       description =
           """
           **Description**  \n
@@ -169,7 +171,7 @@ public class CodefController {
           - continue2Way=true 인 경우 카카오/간편인증 완료 후 2차 요청 필요  \n
           - twoWayInfo는 2차 요청 시 그대로 사용  \n
           """)
-  @PostMapping("/treatments")
+  @PostMapping("/medical-records")
   public ResponseEntity<BaseResponse<CodefTreatmentResponse>> getTreatmentInfo(
       @Valid @RequestBody CodefTreatmentRequest request) {
 
@@ -179,7 +181,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 O] CODEF 진료 및 투약정보 조회 2차 요청",
+      summary = "[토큰 X] CODEF 진료 및 투약정보 조회 2차 요청",
       description =
           """
           **Description**  \n
@@ -196,12 +198,14 @@ public class CodefController {
           **Returns**  \n
           CODEF 진료 및 투약정보 최종 조회 결과  \n
           """)
-  @PostMapping("/treatments/2way")
+  @PostMapping("/medical-records/2way")
   public ResponseEntity<BaseResponse<CodefTreatmentResponse>> getTreatmentInfo2Way(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody CodefTreatment2WayRequest request) {
 
-    CodefTreatmentResponse response = codefService.getTreatmentInfo2Way(request);
+    CodefTreatmentResponse response =
+        codefService.getTreatmentInfo2Way(userDetails.getUserId(), request);
 
-    return ResponseEntity.ok(BaseResponse.success(200, "CODEF 진료 및 투약정보 조회 2차 요청 성공", response));
+    return ResponseEntity.ok(BaseResponse.success(200, "CODEF 의료 기록 조회 및 저장 성공", response));
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefTreatment2WayRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/request/CodefTreatment2WayRequest.java
@@ -15,42 +15,76 @@ import lombok.NoArgsConstructor;
 public class CodefTreatment2WayRequest {
 
   @NotBlank(message = "기관코드는 필수입니다.")
+  @Schema(description = "기관코드", example = "0002")
   private String organization;
 
   @NotBlank(message = "로그인 구분은 필수입니다.")
+  @Schema(description = "로그인 구분, 간편인증은 5", example = "5")
   private String loginType;
 
   @NotBlank(message = "간편인증 로그인 구분은 필수입니다.")
+  @Schema(description = "1:카카오톡, 3:삼성패스, 4:KB모바일, 5:통신사, 6:네이버, 8:toss", example = "1")
   private String loginTypeLevel;
 
   @NotBlank(message = "사용자 이름은 필수입니다.")
+  @Schema(description = "사용자 이름", example = "신채린")
   private String userName;
 
   @NotBlank(message = "생년월일은 필수입니다.")
+  @Schema(description = "생년월일 YYYYMMDD", example = "20030709")
   private String identity;
 
   @NotBlank(message = "전화번호는 필수입니다.")
+  @Schema(description = "전화번호", example = "01012345678")
   private String phoneNo;
 
+  @Schema(description = "통신사, loginTypeLevel=5일 때 필수", example = "0")
   private String telecom;
+
+  @Schema(description = "요청 식별 아이디", example = "user1-uuid")
   private String id;
+
+  @Schema(description = "시작일자 yyyyMMdd", example = "20250101")
   private String startDate;
+
+  @Schema(description = "종료일자 yyyyMMdd", example = "20250505")
   private String endDate;
+
+  @Schema(description = "조회대상, 0:전체 / 1:본인 / 2:영유아", example = "1")
   private String type;
+
+  @Schema(description = "약품이미지 포함 여부, 1:포함 / 0:미포함", example = "0")
   private String drugImageYN;
+
+  @Schema(description = "복약지도 포함 여부, 1:포함 / 0:미포함", example = "0")
   private String medicationDirectionYN;
+
+  @Schema(description = "상세 포함 여부, 1:포함 / 0:미포함", example = "0")
   private String detailYN;
+
+  @Schema(description = "보안숫자 제한시간", example = "170")
   private String timeOut;
 
   @Schema(description = "간편인증 완료 여부, 1: 확인", example = "1")
   private String simpleAuth;
 
-  @Schema(description = "보안문자, 자동 인식 실패 시 입력")
+  @Schema(description = "보안문자, 자동 인식 실패 시 입력", example = "")
   private String secureNo;
 
   @Schema(description = "보안문자 새로고침, 0:기본 / 1:재요청 / 2:입력취소", example = "0")
   private String secureNoRefresh;
 
   @NotNull(message = "추가 인증 정보는 필수입니다.")
+  @Schema(
+      description = "1차 응답에서 받은 jobIndex, threadIndex, jti, twoWayTimestamp 값을 그대로 전달",
+      example =
+          """
+          {
+            "jobIndex": 0,
+            "threadIndex": 0,
+            "jti": "69fe473b0f06c0d5a985a9ce",
+            "twoWayTimestamp": 1778272063054
+          }
+          """)
   private Map<String, Object> twoWayInfo;
 }

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefMedicalRecordResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefMedicalRecordResponse.java
@@ -1,0 +1,28 @@
+package com.springboot.iboribe.domain.codef.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "CodefMedicalRecordResponse: CODEF 의료 기록 응답 DTO")
+public class CodefMedicalRecordResponse {
+
+  @Schema(description = "조회 대상 이름 (본인 또는 자녀 이름)", example = "박지안")
+  private String subjectName;
+
+  @Schema(description = "병원 또는 약국 이름", example = "엠메디칼약국[의정부시 충의로]")
+  private String hospitalName;
+
+  @Schema(description = "진료 시작일", example = "20260331")
+  private String treatDate;
+
+  @Schema(description = "진료 유형", example = "처방조제")
+  private String treatType;
+
+  @Schema(description = "투약 정보 목록")
+  private List<CodefMedicationResponse> medications;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefMedicationResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefMedicationResponse.java
@@ -1,0 +1,30 @@
+package com.springboot.iboribe.domain.codef.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "CodefMedicationResponse: CODEF 투약 정보 응답 DTO")
+public class CodefMedicationResponse {
+
+  @Schema(description = "진료 또는 처방 날짜", example = "20260331")
+  private String treatDate;
+
+  @Schema(description = "진료 상세 유형", example = "약국")
+  private String treatTypeDetail;
+
+  @Schema(description = "처방 약 이름", example = "시네츄라시럽(500mL) (Synatura Syrup(500mL))")
+  private String drugName;
+
+  @Schema(description = "약 효능", example = "진해거담제")
+  private String drugEffect;
+
+  @Schema(description = "처방 일수", example = "4")
+  private String prescribeDays;
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefTreatmentResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/dto/response/CodefTreatmentResponse.java
@@ -9,18 +9,26 @@ import lombok.Getter;
 
 @Getter
 @Builder
-@Schema(title = "CodefTreatmentResponse: CODEF 진료 및 투약정보 응답 DTO")
+@Schema(title = "CodefTreatmentResponse: CODEF 의료 기록 조회 응답 DTO")
 public class CodefTreatmentResponse {
 
+  @Schema(description = "CODEF 결과 코드", example = "CF-00000")
   private String resultCode;
+
+  @Schema(description = "CODEF 결과 메시지", example = "성공")
   private String resultMessage;
 
+  @Schema(description = "추가 인증 필요 여부", example = "true")
   private Boolean continue2Way;
+
+  @Schema(description = "추가 인증 방식", example = "simpleAuth")
   private String method;
+
+  @Schema(description = "2차 요청에 필요한 추가 인증 정보")
   private Map<String, Object> twoWayInfo;
 
-  @Schema(description = "진료 및 투약정보 목록")
-  private List<Map<String, Object>> treatments;
+  @Schema(description = "정제된 의료 기록 목록")
+  private List<CodefMedicalRecordResponse> medicalRecords;
 
   @Schema(description = "CODEF 원본 응답 데이터")
   private Map<String, Object> rawData;

--- a/src/main/java/com/springboot/iboribe/domain/codef/mapper/CodefRequestBodyMapper.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/mapper/CodefRequestBodyMapper.java
@@ -1,0 +1,78 @@
+package com.springboot.iboribe.domain.codef.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildList2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefChildRegister2WayRequest;
+import com.springboot.iboribe.domain.codef.dto.request.CodefTreatment2WayRequest;
+
+@Component
+public class CodefRequestBodyMapper {
+
+  public Map<String, Object> toChildRegister2WayBody(CodefChildRegister2WayRequest request) {
+    Map<String, Object> body = new HashMap<>();
+
+    body.put("organization", request.getOrganization());
+    body.put("loginType", request.getLoginType());
+    body.put("loginTypeLevel", request.getLoginTypeLevel());
+    body.put("userName", request.getUserName());
+    body.put("identity", request.getIdentity());
+    body.put("phoneNo", request.getPhoneNo());
+    body.put("telecom", request.getTelecom());
+    body.put("id", request.getId());
+    body.put("simpleAuth", request.getSimpleAuth());
+    body.put("childName", request.getChildName());
+    body.put("is2Way", true);
+    body.put("twoWayInfo", request.getTwoWayInfo());
+
+    return body;
+  }
+
+  public Map<String, Object> toChildList2WayBody(CodefChildList2WayRequest request) {
+    Map<String, Object> body = new HashMap<>();
+
+    body.put("organization", request.getOrganization());
+    body.put("loginType", request.getLoginType());
+    body.put("loginTypeLevel", request.getLoginTypeLevel());
+    body.put("userName", request.getUserName());
+    body.put("identity", request.getIdentity());
+    body.put("phoneNo", request.getPhoneNo());
+    body.put("telecom", request.getTelecom());
+    body.put("id", request.getId());
+    body.put("simpleAuth", request.getSimpleAuth());
+    body.put("is2Way", true);
+    body.put("twoWayInfo", request.getTwoWayInfo());
+
+    return body;
+  }
+
+  public Map<String, Object> toTreatment2WayBody(CodefTreatment2WayRequest request) {
+    Map<String, Object> body = new HashMap<>();
+
+    body.put("organization", request.getOrganization());
+    body.put("loginType", request.getLoginType());
+    body.put("loginTypeLevel", request.getLoginTypeLevel());
+    body.put("userName", request.getUserName());
+    body.put("identity", request.getIdentity());
+    body.put("phoneNo", request.getPhoneNo());
+    body.put("telecom", request.getTelecom());
+    body.put("id", request.getId());
+    body.put("startDate", request.getStartDate());
+    body.put("endDate", request.getEndDate());
+    body.put("type", request.getType());
+    body.put("drugImageYN", request.getDrugImageYN());
+    body.put("medicationDirectionYN", request.getMedicationDirectionYN());
+    body.put("detailYN", request.getDetailYN());
+    body.put("timeOut", request.getTimeOut());
+    body.put("simpleAuth", request.getSimpleAuth());
+    body.put("secureNo", request.getSecureNo());
+    body.put("secureNoRefresh", request.getSecureNoRefresh());
+    body.put("is2Way", true);
+    body.put("twoWayInfo", request.getTwoWayInfo());
+
+    return body;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/mapper/CodefResponseMapper.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/mapper/CodefResponseMapper.java
@@ -1,0 +1,216 @@
+package com.springboot.iboribe.domain.codef.mapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildListResponse;
+import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicalRecordResponse;
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicationResponse;
+import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
+import com.springboot.iboribe.domain.codef.exception.CodefErrorCode;
+import com.springboot.iboribe.global.exception.CustomException;
+
+@Component
+public class CodefResponseMapper {
+
+  public CodefChildRegisterResponse toChildRegisterResponse(Map<String, Object> response) {
+    Object resultObject = response.get("result");
+
+    if (!(resultObject instanceof Map<?, ?> result)) {
+      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
+    }
+
+    Object dataObject = response.get("data");
+
+    Map<?, ?> data = null;
+    if (dataObject instanceof Map<?, ?> dataMap) {
+      data = dataMap;
+    }
+
+    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
+    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
+
+    return CodefChildRegisterResponse.builder()
+        .resultCode(toNullableString(result.get("code")))
+        .resultMessage(toNullableString(result.get("message")))
+        .continue2Way(continue2Way)
+        .method(data != null ? toNullableString(data.get("method")) : null)
+        .twoWayInfo(twoWayInfo)
+        .resRegistrationStatus(
+            data != null ? toNullableString(data.get("resRegistrationStatus")) : null)
+        .resResultDesc(data != null ? toNullableString(data.get("resResultDesc")) : null)
+        .rawData(response)
+        .build();
+  }
+
+  public CodefChildListResponse toChildListResponse(Map<String, Object> response) {
+    Object resultObject = response.get("result");
+
+    if (!(resultObject instanceof Map<?, ?> result)) {
+      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
+    }
+
+    Object dataObject = response.get("data");
+
+    Map<?, ?> data = null;
+    if (dataObject instanceof Map<?, ?> dataMap) {
+      data = dataMap;
+    }
+
+    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
+    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
+    List<Map<String, Object>> children = extractChildren(dataObject, continue2Way);
+
+    return CodefChildListResponse.builder()
+        .resultCode(toNullableString(result.get("code")))
+        .resultMessage(toNullableString(result.get("message")))
+        .continue2Way(continue2Way)
+        .method(data != null ? toNullableString(data.get("method")) : null)
+        .twoWayInfo(twoWayInfo)
+        .children(children)
+        .rawData(response)
+        .build();
+  }
+
+  public CodefTreatmentResponse toTreatmentResponse(Map<String, Object> response) {
+    Object resultObject = response.get("result");
+
+    if (!(resultObject instanceof Map<?, ?> result)) {
+      throw new CustomException(CodefErrorCode.CODEF_INVALID_RESPONSE);
+    }
+
+    Object dataObject = response.get("data");
+
+    Map<?, ?> data = null;
+    if (dataObject instanceof Map<?, ?> dataMap) {
+      data = dataMap;
+    }
+
+    Boolean continue2Way = data != null ? (Boolean) data.get("continue2Way") : null;
+    Map<String, Object> twoWayInfo = extractTwoWayInfo(data, continue2Way);
+    List<CodefMedicalRecordResponse> medicalRecords =
+        extractMedicalRecords(dataObject, continue2Way);
+
+    return CodefTreatmentResponse.builder()
+        .resultCode(toNullableString(result.get("code")))
+        .resultMessage(toNullableString(result.get("message")))
+        .continue2Way(continue2Way)
+        .method(data != null ? toNullableString(data.get("method")) : null)
+        .twoWayInfo(twoWayInfo)
+        .medicalRecords(medicalRecords)
+        .rawData(response)
+        .build();
+  }
+
+  private Map<String, Object> extractTwoWayInfo(Map<?, ?> data, Boolean continue2Way) {
+    if (data == null || !Boolean.TRUE.equals(continue2Way)) {
+      return null;
+    }
+
+    Map<String, Object> twoWayInfo = new HashMap<>();
+    twoWayInfo.put("jobIndex", data.get("jobIndex"));
+    twoWayInfo.put("threadIndex", data.get("threadIndex"));
+    twoWayInfo.put("jti", data.get("jti"));
+    twoWayInfo.put("twoWayTimestamp", data.get("twoWayTimestamp"));
+
+    return twoWayInfo;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Map<String, Object>> extractChildren(Object dataObject, Boolean continue2Way) {
+    if (Boolean.TRUE.equals(continue2Way) || dataObject == null) {
+      return null;
+    }
+
+    List<Map<String, Object>> children = new ArrayList<>();
+
+    if (dataObject instanceof List<?> list) {
+      for (Object item : list) {
+        if (item instanceof Map<?, ?> child) {
+          children.add((Map<String, Object>) child);
+        }
+      }
+      return children;
+    }
+
+    if (dataObject instanceof Map<?, ?> child) {
+      children.add((Map<String, Object>) child);
+    }
+
+    return children;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<CodefMedicalRecordResponse> extractMedicalRecords(
+      Object dataObject, Boolean continue2Way) {
+
+    if (Boolean.TRUE.equals(continue2Way) || dataObject == null) {
+      return null;
+    }
+
+    List<CodefMedicalRecordResponse> medicalRecords = new ArrayList<>();
+
+    if (dataObject instanceof List<?> list) {
+      for (Object item : list) {
+        if (item instanceof Map<?, ?> record) {
+          medicalRecords.add(toMedicalRecord((Map<String, Object>) record));
+        }
+      }
+      return medicalRecords;
+    }
+
+    if (dataObject instanceof Map<?, ?> record) {
+      medicalRecords.add(toMedicalRecord((Map<String, Object>) record));
+    }
+
+    return medicalRecords;
+  }
+
+  @SuppressWarnings("unchecked")
+  private CodefMedicalRecordResponse toMedicalRecord(Map<String, Object> record) {
+    Object mediDetailObject = record.get("resMediDetailList");
+
+    List<CodefMedicationResponse> medications = new ArrayList<>();
+
+    if (mediDetailObject instanceof List<?> list) {
+      for (Object item : list) {
+        if (item instanceof Map<?, ?> medication) {
+          medications.add(toMedication((Map<String, Object>) medication));
+        }
+      }
+    }
+
+    return CodefMedicalRecordResponse.builder()
+        .subjectName(toNullableString(record.get("resType")))
+        .hospitalName(toNullableString(record.get("resHospitalName")))
+        .treatDate(toNullableString(record.get("resTreatStartDate")))
+        .treatType(toNullableString(record.get("resTreatType")))
+        .medications(medications)
+        .build();
+  }
+
+  private CodefMedicationResponse toMedication(Map<String, Object> medication) {
+    return CodefMedicationResponse.builder()
+        .treatDate(toNullableString(medication.get("resTreatDate")))
+        .treatTypeDetail(toNullableString(medication.get("resTreatTypeDet")))
+        .drugName(toNullableString(medication.get("resPrescribeDrugName")))
+        .drugEffect(toNullableString(medication.get("resPrescribeDrugEffect")))
+        .prescribeDays(toNullableString(medication.get("resPrescribeDays")))
+        .build();
+  }
+
+  private String toNullableString(Object value) {
+    if (value == null) {
+      return null;
+    }
+
+    String stringValue = String.valueOf(value);
+
+    return stringValue.isBlank() ? null : stringValue;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/codef/service/CodefService.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/service/CodefService.java
@@ -70,5 +70,5 @@ public interface CodefService {
    * @param request 진료/투약 조회 2차 요청 DTO
    * @return 진료/투약 최종 조회 결과
    */
-  CodefTreatmentResponse getTreatmentInfo2Way(CodefTreatment2WayRequest request);
+  CodefTreatmentResponse getTreatmentInfo2Way(Long userId, CodefTreatment2WayRequest request);
 }

--- a/src/main/java/com/springboot/iboribe/domain/codef/service/CodefServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/service/CodefServiceImpl.java
@@ -12,6 +12,7 @@ import com.springboot.iboribe.domain.codef.dto.request.CodefTreatmentRequest;
 import com.springboot.iboribe.domain.codef.dto.response.CodefChildListResponse;
 import com.springboot.iboribe.domain.codef.dto.response.CodefChildRegisterResponse;
 import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
+import com.springboot.iboribe.domain.medicalrecord.service.MedicalRecordSaveService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CodefServiceImpl implements CodefService {
 
   private final CodefClient codefClient;
+  private final MedicalRecordSaveService medicalRecordSaveService;
 
   /** CODEF 자녀 등록 1차 요청 - 인증 요청 및 2Way 여부 확인 */
   @Override
@@ -90,15 +92,12 @@ public class CodefServiceImpl implements CodefService {
 
   /** CODEF 진료 및 투약정보 조회 2차 요청 - 간편인증 완료 후 최종 데이터 조회 */
   @Override
-  public CodefTreatmentResponse getTreatmentInfo2Way(CodefTreatment2WayRequest request) {
-    log.info(
-        "[CODEF] 진료 및 투약정보 조회 2차 요청 시작 - userName: {}, type: {}",
-        request.getUserName(),
-        request.getType());
-
+  @Transactional
+  public CodefTreatmentResponse getTreatmentInfo2Way(
+      Long userId, CodefTreatment2WayRequest request) {
     CodefTreatmentResponse response = codefClient.getTreatmentInfo2Way(request);
 
-    log.info("[CODEF] 진료 및 투약정보 조회 2차 요청 완료 - resultCode: {}", response.getResultCode());
+    medicalRecordSaveService.saveFromCodefResponse(userId, response);
 
     return response;
   }

--- a/src/main/java/com/springboot/iboribe/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/controller/FamilyController.java
@@ -1,0 +1,103 @@
+package com.springboot.iboribe.domain.family.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.springboot.iboribe.domain.family.dto.request.UpdateFamilyCodeRequest;
+import com.springboot.iboribe.domain.family.dto.response.FamilyMemberResponse;
+import com.springboot.iboribe.domain.family.service.FamilyService;
+import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/families")
+@Tag(name = "Family", description = "가족 관리 API")
+public class FamilyController {
+
+  private final FamilyService familyService;
+
+  @Operation(
+      summary = "[토큰 O] 가족 구성원 조회",
+      description =
+          """
+          **Authentication**  \n
+          - JWT 인증 필요  \n
+          - ACCESS_TOKEN 사용  \n
+
+          **Process**  \n
+          - 로그인 사용자의 가족 기준으로 구성원 조회  \n
+
+          **Returns**  \n
+          userId  \n
+          name  \n
+          username  \n
+          familyRole  \n
+          """)
+  @GetMapping("/members")
+  public ResponseEntity<BaseResponse<List<FamilyMemberResponse>>> getFamilyMembers(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    List<FamilyMemberResponse> response = familyService.getFamilyMembers(userDetails.getUserId());
+
+    return ResponseEntity.ok(BaseResponse.success(200, "가족 구성원 조회 성공", response));
+  }
+
+  @Operation(
+      summary = "[토큰 O] 가족 구성원 삭제",
+      description =
+          """
+          **Authentication**  \n
+          - JWT 인증 필요  \n
+          - ACCESS_TOKEN 사용  \n
+
+          **Process**  \n
+          - 로그인 사용자와 삭제 대상 사용자의 동일 가족 여부 검증  \n
+          - 특정 가족 구성원 삭제  \n
+
+          **Returns**  \n
+          가족 구성원 삭제 성공 여부  \n
+          """)
+  @DeleteMapping("/members/{memberId}")
+  public ResponseEntity<BaseResponse<Void>> deleteFamilyMember(
+      @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long memberId) {
+    familyService.deleteFamilyMember(userDetails.getUserId(), memberId);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "가족 구성원 삭제 성공", null));
+  }
+
+  @Operation(
+      summary = "[토큰 O] 가족고유번호 수정",
+      description =
+          """
+          **Authentication**  \n
+          - JWT 인증 필요  \n
+          - ACCESS_TOKEN 사용  \n
+
+          **Parameters**  \n
+          familyCode: 수정할 가족고유번호  \n
+
+          **Process**  \n
+          - 로그인 사용자의 가족고유번호 수정  \n
+          - 가족고유번호 중복 검증  \n
+
+          **Returns**  \n
+          가족고유번호 수정 성공 여부  \n
+          """)
+  @PatchMapping
+  public ResponseEntity<BaseResponse<Void>> updateFamilyCode(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody UpdateFamilyCodeRequest request) {
+    familyService.updateFamilyCode(userDetails.getUserId(), request);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "가족고유번호 수정 성공", null));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/dto/request/UpdateFamilyCodeRequest.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/dto/request/UpdateFamilyCodeRequest.java
@@ -1,0 +1,22 @@
+package com.springboot.iboribe.domain.family.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateFamilyCodeRequest {
+
+  @NotBlank(message = "가족고유번호는 필수입니다.")
+  @Size(min = 8, max = 30, message = "가족고유번호는 8자 이상 30자 이하로 입력해야 합니다.")
+  @Pattern(
+      regexp = "^(?=.*[A-Za-z])(?=.*[!@#$%^&*()_+=\\-{}\\[\\]:;\"'<>,.?/]).{8,30}$",
+      message = "가족고유번호는 8자 이상이며 영문자와 특수문자를 포함해야 합니다.")
+  @Schema(description = "수정할 가족고유번호", example = "NewFamily!123")
+  private String familyCode;
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/dto/response/FamilyMemberResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/dto/response/FamilyMemberResponse.java
@@ -1,0 +1,50 @@
+package com.springboot.iboribe.domain.family.dto.response;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
+import com.springboot.iboribe.domain.user.entity.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "FamilyMemberResponse: 가족 구성원 조회 응답 DTO")
+public class FamilyMemberResponse {
+
+  @Schema(description = "구성원 ID", example = "1")
+  private Long memberId;
+
+  @Schema(description = "구성원 이름", example = "김지윤")
+  private String name;
+
+  @Schema(description = "사용자 아이디, 자녀인 경우 null", example = "mom_jiyoon")
+  private String username;
+
+  @Schema(description = "가족 역할, 자녀인 경우 null", example = "MOTHER")
+  private FamilyRole familyRole;
+
+  @Schema(description = "구성원 타입, USER 또는 CHILD", example = "USER")
+  private String memberType;
+
+  public static FamilyMemberResponse fromUser(User user) {
+    return FamilyMemberResponse.builder()
+        .memberId(user.getId())
+        .name(user.getName())
+        .username(user.getUsername())
+        .familyRole(user.getFamilyRole())
+        .memberType("USER")
+        .build();
+  }
+
+  public static FamilyMemberResponse fromChild(Child child) {
+    return FamilyMemberResponse.builder()
+        .memberId(child.getId())
+        .name(child.getName())
+        .username(null)
+        .familyRole(child.getFamilyRole())
+        .memberType("CHILD")
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/entity/Family.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/entity/Family.java
@@ -27,4 +27,8 @@ public class Family {
 
   @Column(nullable = false, unique = true, length = 20)
   private String familyCode;
+
+  public void updateFamilyCode(String familyCode) {
+    this.familyCode = familyCode;
+  }
 }

--- a/src/main/java/com/springboot/iboribe/domain/family/entity/FamilyRole.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/entity/FamilyRole.java
@@ -1,0 +1,18 @@
+package com.springboot.iboribe.domain.family.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FamilyRole {
+  CHILD("아이"),
+  MOTHER("엄마"),
+  FATHER("아빠"),
+  GRANDMOTHER("할머니"),
+  GRANDFATHER("할아버지"),
+  SIBLING("형제자매"),
+  RELATIVE("친척");
+
+  private final String description;
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/exception/FamilyErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/exception/FamilyErrorCode.java
@@ -1,0 +1,24 @@
+package com.springboot.iboribe.domain.family.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.springboot.iboribe.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FamilyErrorCode implements BaseErrorCode {
+  ALREADY_EXIST_FAMILY_CODE("FAMILY4001", "이미 사용 중인 가족고유번호입니다.", HttpStatus.BAD_REQUEST),
+  CANNOT_DELETE_SELF("FAMILY4002", "본인은 가족 구성원에서 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+  NOT_SAME_FAMILY("FAMILY4031", "같은 가족 구성원만 접근할 수 있습니다.", HttpStatus.FORBIDDEN),
+
+  FAMILY_NOT_FOUND("FAMILY4041", "가족 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  FAMILY_MEMBER_NOT_FOUND("FAMILY4042", "가족 구성원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/service/FamilyService.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/service/FamilyService.java
@@ -1,0 +1,15 @@
+package com.springboot.iboribe.domain.family.service;
+
+import java.util.List;
+
+import com.springboot.iboribe.domain.family.dto.request.UpdateFamilyCodeRequest;
+import com.springboot.iboribe.domain.family.dto.response.FamilyMemberResponse;
+
+public interface FamilyService {
+
+  List<FamilyMemberResponse> getFamilyMembers(Long loginUserId);
+
+  void deleteFamilyMember(Long loginUserId, Long memberId);
+
+  void updateFamilyCode(Long loginUserId, UpdateFamilyCodeRequest request);
+}

--- a/src/main/java/com/springboot/iboribe/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/service/FamilyServiceImpl.java
@@ -1,0 +1,100 @@
+package com.springboot.iboribe.domain.family.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.child.repository.ChildRepository;
+import com.springboot.iboribe.domain.family.dto.request.UpdateFamilyCodeRequest;
+import com.springboot.iboribe.domain.family.dto.response.FamilyMemberResponse;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.exception.FamilyErrorCode;
+import com.springboot.iboribe.domain.family.repository.FamilyRepository;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FamilyServiceImpl implements FamilyService {
+
+  private final UserRepository userRepository;
+  private final FamilyRepository familyRepository;
+  private final ChildRepository childRepository;
+
+  @Override
+  public List<FamilyMemberResponse> getFamilyMembers(Long loginUserId) {
+    User loginUser = getUser(loginUserId);
+    Family family = loginUser.getFamily();
+
+    List<FamilyMemberResponse> responses = new ArrayList<>();
+
+    responses.addAll(
+        userRepository.findAllByFamily(family).stream()
+            .map(FamilyMemberResponse::fromUser)
+            .toList());
+
+    responses.addAll(
+        childRepository.findAllByFamily(family).stream()
+            .map(FamilyMemberResponse::fromChild)
+            .toList());
+
+    return responses;
+  }
+
+  @Override
+  @Transactional
+  public void deleteFamilyMember(Long loginUserId, Long memberId) {
+    if (loginUserId.equals(memberId)) {
+      throw new CustomException(FamilyErrorCode.CANNOT_DELETE_SELF);
+    }
+
+    User loginUser = getUser(loginUserId);
+
+    User targetUser =
+        userRepository
+            .findById(memberId)
+            .orElseThrow(() -> new CustomException(FamilyErrorCode.FAMILY_MEMBER_NOT_FOUND));
+
+    validateSameFamily(targetUser, loginUser.getFamily());
+
+    userRepository.delete(targetUser);
+  }
+
+  @Override
+  @Transactional
+  public void updateFamilyCode(Long loginUserId, UpdateFamilyCodeRequest request) {
+    User loginUser = getUser(loginUserId);
+    Family family = loginUser.getFamily();
+
+    if (familyRepository.existsByFamilyCode(request.getFamilyCode())) {
+      throw new CustomException(FamilyErrorCode.ALREADY_EXIST_FAMILY_CODE);
+    }
+
+    family.updateFamilyCode(request.getFamilyCode());
+  }
+
+  private User getUser(Long userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+  }
+
+  private Family getFamily(Long familyId) {
+    return familyRepository
+        .findById(familyId)
+        .orElseThrow(() -> new CustomException(FamilyErrorCode.FAMILY_NOT_FOUND));
+  }
+
+  private void validateSameFamily(User user, Family family) {
+    if (!user.getFamily().getId().equals(family.getId())) {
+      throw new CustomException(FamilyErrorCode.NOT_SAME_FAMILY);
+    }
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/controller/MedicalRecordController.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/controller/MedicalRecordController.java
@@ -1,0 +1,76 @@
+package com.springboot.iboribe.domain.medicalrecord.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordDetailResponse;
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordGroupResponse;
+import com.springboot.iboribe.domain.medicalrecord.service.MedicalRecordQueryService;
+import com.springboot.iboribe.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/medical-records")
+@Tag(name = "MedicalRecord", description = "의료 기록 조회 API")
+public class MedicalRecordController {
+
+  private final MedicalRecordQueryService medicalRecordQueryService;
+
+  @Operation(
+      summary = "[토큰 O] 가족 전체 의료 기록 조회",
+      description =
+          """
+          **Description** \n
+          로그인한 사용자의 가족 전체 의료 기록을 조회합니다. \n
+
+          **기능** \n
+          - 아이별 의료 기록 그룹화 \n
+          - 연/월 기준 조회 가능 \n
+          - 캘린더 화면에서 사용 가능 \n
+
+          **Query Parameter** \n
+          - year: 조회 연도 \n
+          - month: 조회 월 \n
+
+          **Example** \n
+          GET /api/medical-records?year=2026&month=5
+          """)
+  @GetMapping
+  public ResponseEntity<BaseResponse<List<MedicalRecordGroupResponse>>> getMedicalRecords(
+      @RequestParam int year, @RequestParam int month) {
+
+    List<MedicalRecordGroupResponse> response =
+        medicalRecordQueryService.getMedicalRecords(year, month);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "가족 전체 의료 기록 조회 성공", response));
+  }
+
+  @Operation(
+      summary = "[토큰 O] 의료 기록 상세 조회",
+      description =
+          """
+          **Description** \n
+          특정 의료 기록 상세 정보를 조회합니다. \n
+
+          **기능** \n
+          - 병원 정보 조회 \n
+          - 진료 유형 조회 \n
+          - 약 정보 조회 \n
+          - 복용 일수 조회 \n
+          """)
+  @GetMapping("/{recordId}")
+  public ResponseEntity<BaseResponse<MedicalRecordDetailResponse>> getMedicalRecordDetail(
+      @PathVariable Long recordId) {
+
+    MedicalRecordDetailResponse response =
+        medicalRecordQueryService.getMedicalRecordDetail(recordId);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "의료 기록 상세 조회 성공", response));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordDetailResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordDetailResponse.java
@@ -1,0 +1,44 @@
+package com.springboot.iboribe.domain.medicalrecord.dto.response;
+
+import java.util.List;
+
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "MedicalRecordDetailResponse: 의료 기록 상세 응답 DTO")
+public class MedicalRecordDetailResponse {
+
+  @Schema(description = "의료 기록 ID", example = "10")
+  private Long recordId;
+
+  @Schema(description = "자녀 이름", example = "박지안")
+  private String childName;
+
+  @Schema(description = "진료 또는 조제 날짜", example = "20260331")
+  private String treatDate;
+
+  @Schema(description = "병원 또는 약국 이름", example = "엠메디칼약국[의정부시 충의로]")
+  private String hospitalName;
+
+  @Schema(description = "진료 유형", example = "처방조제")
+  private String treatType;
+
+  @Schema(description = "투약 상세 정보 목록")
+  private List<MedicationDetailResponse> medications;
+
+  public static MedicalRecordDetailResponse from(MedicalRecord record) {
+    return MedicalRecordDetailResponse.builder()
+        .recordId(record.getId())
+        .childName(record.getChild().getName())
+        .treatDate(record.getTreatDate())
+        .hospitalName(record.getHospitalName())
+        .treatType(record.getTreatType())
+        .medications(record.getMedications().stream().map(MedicationDetailResponse::from).toList())
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordGroupResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordGroupResponse.java
@@ -1,0 +1,22 @@
+package com.springboot.iboribe.domain.medicalrecord.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "MedicalRecordGroupResponse: 아이별 의료 기록 그룹 응답 DTO")
+public class MedicalRecordGroupResponse {
+
+  @Schema(description = "자녀 ID", example = "1")
+  private Long childId;
+
+  @Schema(description = "자녀 이름", example = "박지안")
+  private String childName;
+
+  @Schema(description = "해당 자녀의 의료 기록 목록")
+  private List<MedicalRecordSummaryResponse> records;
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordSummaryResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicalRecordSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.springboot.iboribe.domain.medicalrecord.dto.response;
+
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "MedicalRecordSummaryResponse: 의료 기록 요약 응답 DTO")
+public class MedicalRecordSummaryResponse {
+
+  @Schema(description = "의료 기록 ID", example = "10")
+  private Long recordId;
+
+  @Schema(description = "진료 또는 조제 날짜", example = "20260331")
+  private String treatDate;
+
+  @Schema(description = "병원 또는 약국 이름", example = "엠메디칼약국[의정부시 충의로]")
+  private String hospitalName;
+
+  @Schema(description = "진료 유형", example = "처방조제")
+  private String treatType;
+
+  public static MedicalRecordSummaryResponse from(MedicalRecord record) {
+    return MedicalRecordSummaryResponse.builder()
+        .recordId(record.getId())
+        .treatDate(record.getTreatDate())
+        .hospitalName(record.getHospitalName())
+        .treatType(record.getTreatType())
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicationDetailResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/dto/response/MedicationDetailResponse.java
@@ -1,0 +1,30 @@
+package com.springboot.iboribe.domain.medicalrecord.dto.response;
+
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicationResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "MedicationDetailResponse: 투약 상세 응답 DTO")
+public class MedicationDetailResponse {
+
+  @Schema(description = "처방 약 이름", example = "시네츄라시럽(500mL)")
+  private String drugName;
+
+  @Schema(description = "약 효능", example = "진해거담제")
+  private String drugEffect;
+
+  @Schema(description = "처방 일수", example = "4")
+  private String prescribeDays;
+
+  public static MedicationDetailResponse from(CodefMedicationResponse medication) {
+    return MedicationDetailResponse.builder()
+        .drugName(medication.getDrugName())
+        .drugEffect(medication.getDrugEffect())
+        .prescribeDays(medication.getPrescribeDays())
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/entity/MedicalRecord.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/entity/MedicalRecord.java
@@ -1,0 +1,55 @@
+package com.springboot.iboribe.domain.medicalrecord.entity;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicationResponse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "medical_records")
+public class MedicalRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "child_id", nullable = false)
+  private Child child;
+
+  @Column(nullable = false, length = 100)
+  private String hospitalName;
+
+  @Column(nullable = false, length = 8)
+  private String treatDate;
+
+  @Column(length = 30)
+  private String treatType;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private List<CodefMedicationResponse> medications;
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
@@ -1,0 +1,18 @@
+package com.springboot.iboribe.domain.medicalrecord.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+
+public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Long> {
+
+  Optional<MedicalRecord> findByChildAndHospitalNameAndTreatDateAndTreatType(
+      Child child, String hospitalName, String treatDate, String treatType);
+
+  List<MedicalRecord> findAllByTreatDateBetweenOrderByTreatDateDesc(
+      String startDate, String endDate);
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryService.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryService.java
@@ -1,0 +1,13 @@
+package com.springboot.iboribe.domain.medicalrecord.service;
+
+import java.util.List;
+
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordDetailResponse;
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordGroupResponse;
+
+public interface MedicalRecordQueryService {
+
+  List<MedicalRecordGroupResponse> getMedicalRecords(int year, int month);
+
+  MedicalRecordDetailResponse getMedicalRecordDetail(Long recordId);
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryServiceImpl.java
@@ -1,0 +1,64 @@
+package com.springboot.iboribe.domain.medicalrecord.service;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordDetailResponse;
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordGroupResponse;
+import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordSummaryResponse;
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MedicalRecordQueryServiceImpl implements MedicalRecordQueryService {
+
+  private final MedicalRecordRepository medicalRecordRepository;
+
+  @Override
+  public List<MedicalRecordGroupResponse> getMedicalRecords(int year, int month) {
+    YearMonth yearMonth = YearMonth.of(year, month);
+
+    String startDate = yearMonth.atDay(1).format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+    String endDate =
+        yearMonth.atEndOfMonth().format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+
+    List<MedicalRecord> records =
+        medicalRecordRepository.findAllByTreatDateBetweenOrderByTreatDateDesc(startDate, endDate);
+
+    Map<Long, List<MedicalRecord>> groupedByChild =
+        records.stream().collect(Collectors.groupingBy(record -> record.getChild().getId()));
+
+    return groupedByChild.entrySet().stream()
+        .map(
+            entry -> {
+              MedicalRecord firstRecord = entry.getValue().get(0);
+
+              return MedicalRecordGroupResponse.builder()
+                  .childId(firstRecord.getChild().getId())
+                  .childName(firstRecord.getChild().getName())
+                  .records(
+                      entry.getValue().stream().map(MedicalRecordSummaryResponse::from).toList())
+                  .build();
+            })
+        .toList();
+  }
+
+  @Override
+  public MedicalRecordDetailResponse getMedicalRecordDetail(Long recordId) {
+    MedicalRecord record =
+        medicalRecordRepository
+            .findById(recordId)
+            .orElseThrow(() -> new IllegalArgumentException("의료 기록을 찾을 수 없습니다."));
+
+    return MedicalRecordDetailResponse.from(record);
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordSaveService.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordSaveService.java
@@ -1,0 +1,8 @@
+package com.springboot.iboribe.domain.medicalrecord.service;
+
+import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
+
+public interface MedicalRecordSaveService {
+
+  void saveFromCodefResponse(Long userId, CodefTreatmentResponse response);
+}

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordSaveServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordSaveServiceImpl.java
@@ -1,0 +1,75 @@
+package com.springboot.iboribe.domain.medicalrecord.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.child.repository.ChildRepository;
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicalRecordResponse;
+import com.springboot.iboribe.domain.codef.dto.response.CodefTreatmentResponse;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MedicalRecordSaveServiceImpl implements MedicalRecordSaveService {
+
+  private final UserRepository userRepository;
+  private final ChildRepository childRepository;
+  private final MedicalRecordRepository medicalRecordRepository;
+
+  @Override
+  public void saveFromCodefResponse(Long userId, CodefTreatmentResponse response) {
+    if (response.getMedicalRecords() == null || response.getMedicalRecords().isEmpty()) {
+      return;
+    }
+
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+    Family family = user.getFamily();
+
+    for (CodefMedicalRecordResponse record : response.getMedicalRecords()) {
+      if (record.getSubjectName() == null || "본인".equals(record.getSubjectName())) {
+        continue;
+      }
+
+      Child child =
+          childRepository
+              .findByFamilyAndName(family, record.getSubjectName())
+              .orElseGet(
+                  () ->
+                      childRepository.save(
+                          Child.builder().family(family).name(record.getSubjectName()).build()));
+
+      boolean alreadyExists =
+          medicalRecordRepository
+              .findByChildAndHospitalNameAndTreatDateAndTreatType(
+                  child, record.getHospitalName(), record.getTreatDate(), record.getTreatType())
+              .isPresent();
+
+      if (alreadyExists) {
+        continue;
+      }
+
+      medicalRecordRepository.save(
+          MedicalRecord.builder()
+              .child(child)
+              .hospitalName(record.getHospitalName())
+              .treatDate(record.getTreatDate())
+              .treatType(record.getTreatType())
+              .medications(record.getMedications())
+              .build());
+    }
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/user/controller/UserController.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/controller/UserController.java
@@ -1,0 +1,52 @@
+package com.springboot.iboribe.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
+import com.springboot.iboribe.domain.user.service.UserService;
+import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.exception.CustomException;
+import com.springboot.iboribe.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "User", description = "사용자 API")
+public class UserController {
+
+  private final UserService userService;
+
+  @Operation(
+      summary = "[토큰 O] 내 정보 조회",
+      description =
+          """
+          **Authentication**  \n
+          - JWT 인증 필요  \n
+          - ACCESS_TOKEN 사용  \n
+
+          **Returns**  \n
+          userId  \n
+          name  \n
+          username  \n
+          familyId  \n
+          familyCode  \n
+          familyRole  \n
+          """)
+  @GetMapping("/users/me")
+  public ResponseEntity<BaseResponse<UserInfoResponse>> getUserInfo(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    if (userDetails == null) {
+      throw new CustomException(AuthErrorCode.AUTHENTICATION_REQUIRED);
+    }
+    UserInfoResponse response = userService.getUserInfo(userDetails.getUserId());
+    return ResponseEntity.ok(BaseResponse.success(200, "사용자 정보 조회 성공", response));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,30 @@
+package com.springboot.iboribe.domain.user.dto.response;
+
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
+import com.springboot.iboribe.domain.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+
+  private Long userId;
+  private String name;
+  private String username;
+  private Long familyId;
+  private String familyCode;
+  private FamilyRole familyRole;
+
+  public static UserInfoResponse from(User user) {
+    return UserInfoResponse.builder()
+        .userId(user.getId())
+        .name(user.getName())
+        .username(user.getUsername())
+        .familyId(user.getFamily().getId())
+        .familyCode(user.getFamily().getFamilyCode())
+        .familyRole(user.getFamilyRole())
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/user/entity/User.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.springboot.iboribe.domain.user.entity;
 import jakarta.persistence.*;
 
 import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
 
 import lombok.*;
 
@@ -30,4 +31,8 @@ public class User {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "family_id", nullable = false)
   private Family family;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private FamilyRole familyRole;
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.springboot.iboribe.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.springboot.iboribe.domain.family.entity.Family;
 import com.springboot.iboribe.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -11,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByUsername(String username);
 
   boolean existsByUsername(String username);
+
+  List<User> findAllByFamily(Family family);
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/service/UserService.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.springboot.iboribe.domain.user.service;
+
+import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
+
+public interface UserService {
+
+  UserInfoResponse getUserInfo(Long userId);
+}

--- a/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,30 @@
+package com.springboot.iboribe.domain.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserInfoResponse getUserInfo(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+    return UserInfoResponse.from(user);
+  }
+}

--- a/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
@@ -38,7 +38,10 @@ public class SecurityConfig {
                         "/api/auth/**",
                         "/api/hospital/**",
                         "/api/predict/**",
-                        "/api/district/**")
+                        "/api/district/**",
+                        "/api/codef/medical-records",
+                        "/api/codef/children/register",
+                        "/api/codef/children/list")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/springboot/iboribe/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/springboot/iboribe/global/filter/JwtAuthenticationFilter.java
@@ -10,6 +10,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -28,6 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
+  private final UserDetailsService userDetailsService;
+
   private static final AntPathMatcher pathMatcher = new AntPathMatcher();
 
   @Override
@@ -36,6 +41,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     return pathMatcher.match("/api/auth/signup", uri)
         || pathMatcher.match("/api/auth/login", uri)
+        || pathMatcher.match("/api/auth/demo-login", uri)
+        || pathMatcher.match("/api/codef/medical-records", uri)
+        || pathMatcher.match("/api/codef/children/register", uri)
+        || pathMatcher.match("/api/codef/children/list", uri)
         || pathMatcher.match("/swagger-ui/**", uri)
         || pathMatcher.match("/swagger-ui.html", uri)
         || pathMatcher.match("/v3/api-docs/**", uri)
@@ -51,13 +60,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       String accessToken = jwtProvider.extractAccessToken(request);
 
       if (accessToken != null && jwtProvider.validateToken(accessToken, TokenType.ACCESS_TOKEN)) {
-        Long userId = jwtProvider.getUserIdFromToken(accessToken);
         String username = jwtProvider.getUsernameFromToken(accessToken);
 
-        UsernamePasswordAuthenticationToken authentication =
-            new UsernamePasswordAuthenticationToken(username, null, null);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
-        authentication.setDetails(userId);
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
       }
 

--- a/src/main/java/com/springboot/iboribe/global/init/DemoDataLoader.java
+++ b/src/main/java/com/springboot/iboribe/global/init/DemoDataLoader.java
@@ -1,0 +1,217 @@
+package com.springboot.iboribe.global.init;
+
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.child.repository.ChildRepository;
+import com.springboot.iboribe.domain.codef.dto.response.CodefMedicationResponse;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.entity.FamilyRole;
+import com.springboot.iboribe.domain.family.repository.FamilyRepository;
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DemoDataLoader implements CommandLineRunner {
+
+  private final UserRepository userRepository;
+  private final FamilyRepository familyRepository;
+  private final ChildRepository childRepository;
+  private final MedicalRecordRepository medicalRecordRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  @Transactional
+  public void run(String... args) {
+    log.info("데모 데이터 초기화 시작...");
+
+    Family family = getOrCreateDemoFamily();
+    createDemoUsersIfNotExists(family);
+
+    Child jiAn = getOrCreateChild(family, "박지안");
+    Child seoYeon = getOrCreateChild(family, "박서연");
+
+    createMedicalRecordIfNotExists(
+        jiAn,
+        "연세이비인후과의원",
+        "20251203",
+        "일반외래",
+        List.of(createMedication("20251203", "외래", "부루펜시럽", "해열, 진통, 소염제", "3")));
+
+    createMedicalRecordIfNotExists(
+        jiAn,
+        "연세웰이비인후과의원",
+        "20251218",
+        "일반외래",
+        List.of(
+            createMedication("20251218", "외래", "코미시럽", "항히스타민제", "3"),
+            createMedication("20251218", "외래", "뮤코졸정", "진해거담제", "3")));
+
+    createMedicalRecordIfNotExists(
+        jiAn,
+        "강북삼성병원",
+        "20260115",
+        "일반외래",
+        List.of(createMedication("20260115", "외래", "타이레놀현탁액", "해열진통제", "2")));
+
+    createMedicalRecordIfNotExists(
+        jiAn,
+        "서울센트럴이비인후과의원",
+        "20260307",
+        "일반외래",
+        List.of(
+            createMedication("20260307", "외래", "시네츄라시럽", "진해거담제", "4"),
+            createMedication("20260307", "외래", "비오플250산", "정장제", "4")));
+
+    createMedicalRecordIfNotExists(
+        jiAn,
+        "삼성튼튼소아청소년과의원",
+        "20260418",
+        null,
+        List.of(createMedication("20260418", "외래", "움카민시럽", "기타의 호흡기관용약", "4")));
+
+    createMedicalRecordIfNotExists(
+        seoYeon,
+        "연세우리소아과의원",
+        "20251212",
+        "일반외래",
+        List.of(createMedication("20251212", "외래", "암브록솔시럽", "진해거담제", "3")));
+
+    createMedicalRecordIfNotExists(
+        seoYeon,
+        "정소아과의원",
+        "20260128",
+        "일반외래",
+        List.of(
+            createMedication("20260128", "외래", "페니라민정", "항히스타민제", "2"),
+            createMedication("20260128", "외래", "비오플250산", "정장제", "2")));
+
+    createMedicalRecordIfNotExists(
+        seoYeon,
+        "서울적십자병원",
+        "20260219",
+        "일반외래",
+        List.of(createMedication("20260219", "외래", "부루펜시럽", "해열, 진통, 소염제", "3")));
+
+    createMedicalRecordIfNotExists(
+        seoYeon,
+        "두리이비인후과의원",
+        "20260331",
+        "일반외래",
+        List.of(
+            createMedication("20260331", "외래", "시네츄라시럽", "진해거담제", "4"),
+            createMedication("20260331", "외래", "코미시럽", "항히스타민제", "4")));
+
+    createMedicalRecordIfNotExists(
+        seoYeon,
+        "의료법인소화의원",
+        "20260423",
+        null,
+        List.of(createMedication("20260423", "외래", "타이레놀현탁액", "해열진통제", "2")));
+
+    log.info("데모 데이터 초기화 완료");
+  }
+
+  private Family getOrCreateDemoFamily() {
+    return familyRepository
+        .findByFamilyCode("YoonFamily2026")
+        .orElseGet(
+            () -> familyRepository.save(Family.builder().familyCode("YoonFamily2026").build()));
+  }
+
+  private void createDemoUsersIfNotExists(Family family) {
+    if (!userRepository.existsByUsername("mom_jiyoon")) {
+      User mother =
+          userRepository.save(
+              User.builder()
+                  .name("김지윤")
+                  .username("mom_jiyoon")
+                  .password(passwordEncoder.encode("Demo!1234"))
+                  .family(family)
+                  .familyRole(FamilyRole.MOTHER)
+                  .build());
+
+      log.info("데모 엄마 계정 생성 완료 - userId: {}", mother.getId());
+    }
+
+    if (!userRepository.existsByUsername("dad_hyunwoo")) {
+      User father =
+          userRepository.save(
+              User.builder()
+                  .name("박현우")
+                  .username("dad_hyunwoo")
+                  .password(passwordEncoder.encode("Demo!1234"))
+                  .family(family)
+                  .familyRole(FamilyRole.FATHER)
+                  .build());
+
+      log.info("데모 아빠 계정 생성 완료 - userId: {}", father.getId());
+    }
+  }
+
+  private Child getOrCreateChild(Family family, String childName) {
+    return childRepository
+        .findByFamilyAndName(family, childName)
+        .orElseGet(
+            () ->
+                childRepository.save(
+                    Child.builder()
+                        .family(family)
+                        .name(childName)
+                        .familyRole(FamilyRole.CHILD)
+                        .build()));
+  }
+
+  private void createMedicalRecordIfNotExists(
+      Child child,
+      String hospitalName,
+      String treatDate,
+      String treatType,
+      List<CodefMedicationResponse> medications) {
+    boolean alreadyExists =
+        medicalRecordRepository
+            .findByChildAndHospitalNameAndTreatDateAndTreatType(
+                child, hospitalName, treatDate, treatType)
+            .isPresent();
+
+    if (alreadyExists) {
+      return;
+    }
+
+    medicalRecordRepository.save(
+        MedicalRecord.builder()
+            .child(child)
+            .hospitalName(hospitalName)
+            .treatDate(treatDate)
+            .treatType(treatType)
+            .medications(medications)
+            .build());
+  }
+
+  private CodefMedicationResponse createMedication(
+      String treatDate,
+      String treatTypeDetail,
+      String drugName,
+      String drugEffect,
+      String prescribeDays) {
+    return CodefMedicationResponse.builder()
+        .treatDate(treatDate)
+        .treatTypeDetail(treatTypeDetail)
+        .drugName(drugName)
+        .drugEffect(drugEffect)
+        .prescribeDays(prescribeDays)
+        .build();
+  }
+}

--- a/src/main/java/com/springboot/iboribe/global/security/CustomUserDetails.java
+++ b/src/main/java/com/springboot/iboribe/global/security/CustomUserDetails.java
@@ -33,4 +33,8 @@ public class CustomUserDetails implements UserDetails {
   public String getUsername() {
     return user.getUsername();
   }
+
+  public Long getUserId() {
+    return user.getId();
+  }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #42 


## 📝 요약(Summary)
- 가족 기반 구조를 도입하고 가족 구성원 및 의료 기록 조회 기능 구현
- Family / Child 도메인을 추가하여 가족 단위 데이터를 관리할 수 있도록 구조 확장
- 의료 기록(MedicalRecord) 도메인을 추가하여 가족 전체 진료 및 투약 정보를 조회할 수 있도록 구현
- CODEF 진료/투약 응답 데이터를 내부 의료 기록 구조로 매핑하도록 개선
- 데모 데이터 초기화 기능을 추가하여 실제 조회 테스트가 가능하도록 구성

#### Family / Child 도메인 추가

* Family 엔티티 및 FamilyRole enum 추가
* Child 엔티티 및 Repository 추가
* User ↔ Family 연관관계 추가
* Child에 familyRole(CHILD) 구조 추가

#### 가족 구성원 조회 기능 추가

* Family 구성원 조회 API 구현
* USER / CHILD 타입 구분 응답 구조 추가
* FamilyMemberResponse DTO 추가
* 아이 정보 포함 응답 매핑 추가

#### 의료 기록 도메인 추가

* MedicalRecord 엔티티 및 Repository 추가
* 의료 기록 월별 조회 API 구현
* 의료 기록 상세 조회 API 구현
* 아이별 의료 기록 그룹화 응답 구조 추가

#### CODEF 진료/투약 구조 개선

* CodefMedicalRecordResponse 추가
* CodefMedicationResponse 추가
* CODEF 응답 → MedicalRecord 매핑 로직 추가
* 진료/투약 응답 구조 리팩토링
* 의료 기록 조회용 DTO 구조 개선

#### 인증 및 사용자 구조 리팩토링

* 가족 기반 회원가입 로직으로 변경
* AuthService / AuthServiceImpl 로직 개선
* JWT 인증 객체(CustomUserDetails) 구조 수정
* JwtAuthenticationFilter 및 SecurityConfig 수정

#### 데모 데이터 초기화 추가

* DemoDataLoader 추가
* 가족 / 사용자 / 아이 더미 데이터 생성
* 의료 기록 및 투약 더미 데이터 초기화 추가
* 병원 및 약 정보 기반 테스트 환경 구성


## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
