### PR TITLE
:sparkles: Feat: 가족 알림 기능 구현 및 AI 진료 요약 추가 흐름 리펙토링

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/aisummary/controller/AiSummaryController.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/controller/AiSummaryController.java
@@ -2,6 +2,7 @@ package com.springboot.iboribe.domain.aisummary.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,6 +10,7 @@ import com.springboot.iboribe.domain.aisummary.dto.request.AiSummaryAudioMultipa
 import com.springboot.iboribe.domain.aisummary.dto.response.AiSummaryResponse;
 import com.springboot.iboribe.domain.aisummary.service.AiSummaryService;
 import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,23 +31,23 @@ public class AiSummaryController {
       description =
           """
           **Description**  \n
-          특정 의료 기록에 진료 녹음 파일을 업로드하여 AI 요약을 생성합니다.  \n
+          진료 녹음 파일을 업로드하여 AI 요약을 생성합니다.  \n
 
           **Parameters**  \n
-          recordId: AI 요약을 생성할 의료 기록 ID  \n
+          childId: 자녀 ID (recordId 없을 때 필수)  \n
+          recordId: 기존 진료 기록 ID (선택 - 기존 진료 내역에 연결할 경우에만 입력, 있으면 childId 불필요)  \n
           audioFile: 진료 녹음 오디오 파일  \n
 
           **Process**  \n
+          - recordId 없으면 AI 소스 진료 기록 자동 생성  \n
           - 오디오 파일 업로드  \n
           - OpenAI Whisper/STT로 텍스트 변환  \n
           - 변환된 텍스트를 AI 요약  \n
           - 한줄요약, 진료요약, 주의사항, 다음일정 저장  \n
 
           **Returns**  \n
-          oneLineSummary  \n
-          medicalSummary  \n
-          caution  \n
-          nextSchedule  \n
+          summaryId, childId, recordId  \n
+          oneLineSummary, medicalSummary, caution, nextSchedule  \n
           """,
       requestBody =
           @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -54,12 +56,16 @@ public class AiSummaryController {
                   @Content(
                       mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                       schema = @Schema(implementation = AiSummaryAudioMultipartBody.class))))
-  @PostMapping(value = "/{recordId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<BaseResponse<AiSummaryResponse>> generateSummaryFromAudio(
-      @PathVariable Long recordId,
-      @RequestPart(value = "audioFile", required = true) MultipartFile audioFile) {
+      @RequestParam(required = false) Long childId,
+      @RequestParam(required = false) Long recordId,
+      @RequestPart(value = "audioFile") MultipartFile audioFile,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    AiSummaryResponse response = aiSummaryService.generateSummaryFromAudio(recordId, audioFile);
+    AiSummaryResponse response =
+        aiSummaryService.generateSummaryFromAudio(
+            childId, recordId, audioFile, userDetails.getUserId());
 
     return ResponseEntity.ok(BaseResponse.success(200, "AI 진료 요약 생성 성공", response));
   }

--- a/src/main/java/com/springboot/iboribe/domain/aisummary/exception/AiSummaryErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/exception/AiSummaryErrorCode.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum AiSummaryErrorCode implements BaseErrorCode {
   AUDIO_FILE_EMPTY("AISUM4001", "음성 파일이 비어 있습니다.", HttpStatus.BAD_REQUEST),
   AI_SUMMARY_ALREADY_EXISTS("AISUM4002", "이미 AI 요약이 존재합니다.", HttpStatus.BAD_REQUEST),
+  CHILD_ID_REQUIRED("AISUM4003", "진료 기록 없이 요약 시 자녀 ID가 필요합니다.", HttpStatus.BAD_REQUEST),
 
   AI_SUMMARY_NOT_FOUND("AISUM4041", "AI 요약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 

--- a/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryService.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryService.java
@@ -6,7 +6,8 @@ import com.springboot.iboribe.domain.aisummary.dto.response.AiSummaryResponse;
 
 public interface AiSummaryService {
 
-  AiSummaryResponse generateSummaryFromAudio(Long recordId, MultipartFile audioFile);
+  AiSummaryResponse generateSummaryFromAudio(
+      Long childId, Long recordId, MultipartFile audioFile, Long requesterId);
 
   AiSummaryResponse getAiSummary(Long recordId);
 

--- a/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryServiceImpl.java
@@ -1,5 +1,9 @@
 package com.springboot.iboribe.domain.aisummary.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,9 +13,14 @@ import com.springboot.iboribe.domain.aisummary.entity.AiSummary;
 import com.springboot.iboribe.domain.aisummary.exception.AiSummaryErrorCode;
 import com.springboot.iboribe.domain.aisummary.mapper.AiSummaryMapper;
 import com.springboot.iboribe.domain.aisummary.repository.AiSummaryRepository;
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.child.exception.ChildErrorCode;
+import com.springboot.iboribe.domain.child.repository.ChildRepository;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
+import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecordSource;
 import com.springboot.iboribe.domain.medicalrecord.exception.MedicalRecordErrorCode;
 import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.service.NotificationService;
 import com.springboot.iboribe.global.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
@@ -25,16 +34,16 @@ public class AiSummaryServiceImpl implements AiSummaryService {
 
   private final MedicalRecordRepository medicalRecordRepository;
   private final AiSummaryRepository aiSummaryRepository;
+  private final ChildRepository childRepository;
   private final AiSummaryMapper aiSummaryMapper;
+  private final NotificationService notificationService;
 
   @Override
   @Transactional
-  public AiSummaryResponse generateSummaryFromAudio(Long recordId, MultipartFile audioFile) {
-    MedicalRecord medicalRecord =
-        medicalRecordRepository
-            .findById(recordId)
-            .orElseThrow(
-                () -> new CustomException(MedicalRecordErrorCode.MEDICAL_RECORD_NOT_FOUND));
+  public AiSummaryResponse generateSummaryFromAudio(
+      Long childId, Long recordId, MultipartFile audioFile, Long requesterId) {
+
+    MedicalRecord medicalRecord = resolveOrCreateMedicalRecord(childId, recordId);
 
     if (aiSummaryRepository.existsByMedicalRecord(medicalRecord)) {
       throw new CustomException(AiSummaryErrorCode.AI_SUMMARY_ALREADY_EXISTS);
@@ -43,6 +52,8 @@ public class AiSummaryServiceImpl implements AiSummaryService {
     String transcript = aiSummaryMapper.transcribeAudio(audioFile);
     AiSummary aiSummary =
         aiSummaryRepository.save(aiSummaryMapper.toAiSummaryEntity(medicalRecord, transcript));
+
+    notificationService.createFamilyNotifications(aiSummary, requesterId);
 
     return AiSummaryResponse.from(aiSummary);
   }
@@ -65,5 +76,33 @@ public class AiSummaryServiceImpl implements AiSummaryService {
     }
 
     aiSummaryRepository.deleteByMedicalRecordId(recordId);
+  }
+
+  private MedicalRecord resolveOrCreateMedicalRecord(Long childId, Long recordId) {
+    if (recordId != null) {
+      return medicalRecordRepository
+          .findById(recordId)
+          .orElseThrow(() -> new CustomException(MedicalRecordErrorCode.MEDICAL_RECORD_NOT_FOUND));
+    }
+
+    if (childId == null) {
+      throw new CustomException(AiSummaryErrorCode.CHILD_ID_REQUIRED);
+    }
+
+    Child child =
+        childRepository
+            .findById(childId)
+            .orElseThrow(() -> new CustomException(ChildErrorCode.CHILD_NOT_FOUND));
+
+    String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+    return medicalRecordRepository.save(
+        MedicalRecord.builder()
+            .child(child)
+            .hospitalName("진료 녹음 요약")
+            .treatDate(today)
+            .source(MedicalRecordSource.AI)
+            .medications(List.of())
+            .build());
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/springboot/iboribe/domain/auth/controller/AuthController.java
@@ -47,7 +47,13 @@ public class AuthController {
           - 별도 회원가입 없이 미리 등록된 사용자/아이/진료 기록 데이터 확인 가능  \n
 
           **Process**  \n
-          - 서버에 등록된 mom_jiyoon 계정으로 로그인  \n
+          - 서버에 등록된 mom_jiyoon 계정으로 자동 로그인  \n
+
+          **Demo Accounts** (일반 로그인으로도 사용 가능)  \n
+          가족 고유번호: YoonFamily2026!  \n
+          엄마 - username: mom_jiyoon / password: Demo!1234  \n
+          아빠 - username: dad_hyunwoo / password: Demo!1234  \n
+          할머니 - username: grandma_soon / password: Demo!1234  \n
 
           **Returns**  \n
           userId, name, username  \n
@@ -95,6 +101,12 @@ public class AuthController {
           - 로그인 성공 시 accessToken은 쿠키(HttpOnly)와 body 모두 내려줌  \n
           - 쿠키: 이후 API 요청에 자동 포함  \n
           - body accessToken: 로그인 여부/UI 상태 관리용  \n
+
+          **Demo Accounts**  \n
+          가족 고유번호: YoonFamily2026!  \n
+          엄마 - username: mom_jiyoon / password: Demo!1234  \n
+          아빠 - username: dad_hyunwoo / password: Demo!1234  \n
+          할머니 - username: grandma_soon / password: Demo!1234  \n
 
           **Returns**  \n
           userId, name, username  \n

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/entity/MedicalRecordSource.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/entity/MedicalRecordSource.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MedicalRecordSource {
   CODEF("CODEF로 불러온 과거 진료 내역"),
-  USER("사용자가 직접 등록한 진료 기록");
+  USER("사용자가 직접 등록한 진료 기록"),
+  AI("AI 진료 녹음 요약으로 생성된 기록");
 
   private final String description;
 }

--- a/src/main/java/com/springboot/iboribe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/controller/NotificationController.java
@@ -1,0 +1,76 @@
+package com.springboot.iboribe.domain.notification.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.springboot.iboribe.domain.notification.dto.response.NotificationResponse;
+import com.springboot.iboribe.domain.notification.dto.response.NotificationStatusResponse;
+import com.springboot.iboribe.domain.notification.service.NotificationService;
+import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+@Tag(name = "Notification", description = "알림 API")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @Operation(
+      summary = "[토큰 O] 내 알림 목록 조회",
+      description =
+          """
+          **Returns**  \n
+          id: 알림 ID  \n
+          message: 알림 메시지 (예: 김길동 님께서 아이 우리막둥이의 진료 음성을 요약했습니다.)  \n
+          timeAgo: 상대 시간 (예: 9시간 전)  \n
+          read: 읽음 여부  \n
+          """)
+  @GetMapping
+  public ResponseEntity<BaseResponse<List<NotificationResponse>>> getMyNotifications(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    List<NotificationResponse> response =
+        notificationService.getMyNotifications(userDetails.getUserId());
+
+    return ResponseEntity.ok(BaseResponse.success(200, "알림 목록 조회 성공", response));
+  }
+
+  @Operation(
+      summary = "[토큰 O] 읽지 않은 알림 현황 조회",
+      description =
+          """
+          알림 벨 아이콘의 읽지 않은 알림 여부 확인용  \n
+
+          **Returns**  \n
+          hasUnread: 읽지 않은 알림 존재 여부  \n
+          unreadCount: 읽지 않은 알림 수  \n
+          """)
+  @GetMapping("/unread-status")
+  public ResponseEntity<BaseResponse<NotificationStatusResponse>> getUnreadStatus(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    NotificationStatusResponse response =
+        notificationService.getUnreadStatus(userDetails.getUserId());
+
+    return ResponseEntity.ok(BaseResponse.success(200, "읽지 않은 알림 현황 조회 성공", response));
+  }
+
+  @Operation(summary = "[토큰 O] 전체 알림 읽음 처리", description = "알림 화면 진입 시 모든 알림을 읽음 상태로 처리")
+  @PatchMapping("/read-all")
+  public ResponseEntity<BaseResponse<Void>> markAllAsRead(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    notificationService.markAllAsRead(userDetails.getUserId());
+
+    return ResponseEntity.ok(BaseResponse.success(200, "전체 알림 읽음 처리 성공", null));
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,56 @@
+package com.springboot.iboribe.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.notification.entity.Notification;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+  @Schema(description = "알림 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "알림 메시지", example = "김길동 님께서 아이 우리막둥이의 진료 음성을 요약했습니다.")
+  private String message;
+
+  @Schema(description = "상대 시간", example = "9시간 전")
+  private String timeAgo;
+
+  @Schema(description = "읽음 여부", example = "false")
+  private boolean read;
+
+  public static NotificationResponse from(Notification notification) {
+    String senderName = notification.getSender().getName();
+    String childDisplayName = resolveChildDisplayName(notification.getChild());
+
+    return NotificationResponse.builder()
+        .id(notification.getId())
+        .message(senderName + " 님께서 아이 " + childDisplayName + "의 진료 음성을 요약했습니다.")
+        .timeAgo(formatTimeAgo(notification.getCreateTime()))
+        .read(notification.isRead())
+        .build();
+  }
+
+  private static String resolveChildDisplayName(Child child) {
+    String nickname = child.getNickname();
+    return (nickname != null && !nickname.isBlank()) ? nickname : child.getName();
+  }
+
+  private static String formatTimeAgo(LocalDateTime createTime) {
+    long minutes = ChronoUnit.MINUTES.between(createTime, LocalDateTime.now());
+    if (minutes < 1) return "방금 전";
+    if (minutes < 60) return minutes + "분 전";
+    long hours = minutes / 60;
+    if (hours < 24) return hours + "시간 전";
+    long days = hours / 24;
+    if (days < 7) return days + "일 전";
+    return (days / 7) + "주 전";
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/dto/response/NotificationStatusResponse.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/dto/response/NotificationStatusResponse.java
@@ -1,0 +1,20 @@
+package com.springboot.iboribe.domain.notification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationStatusResponse {
+
+  @Schema(description = "읽지 않은 알림 존재 여부", example = "true")
+  private boolean hasUnread;
+
+  @Schema(description = "읽지 않은 알림 수", example = "3")
+  private long unreadCount;
+
+  public static NotificationStatusResponse of(long unreadCount) {
+    return new NotificationStatusResponse(unreadCount > 0, unreadCount);
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/entity/Notification.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/entity/Notification.java
@@ -1,0 +1,58 @@
+package com.springboot.iboribe.domain.notification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.springboot.iboribe.domain.aisummary.entity.AiSummary;
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.global.common.BaseTimeEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notifications")
+public class Notification extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "receiver_id", nullable = false)
+  private User receiver;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private User sender;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "child_id", nullable = false)
+  private Child child;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "ai_summary_id", nullable = false)
+  private AiSummary aiSummary;
+
+  @Builder.Default
+  @Column(name = "is_read", nullable = false)
+  private boolean read = false;
+
+  public void markAsRead() {
+    this.read = true;
+  }
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,18 @@
+package com.springboot.iboribe.domain.notification.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.springboot.iboribe.global.exception.model.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+  NOTIFICATION_NOT_FOUND("NOTIF4041", "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,29 @@
+package com.springboot.iboribe.domain.notification.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.springboot.iboribe.domain.notification.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  @Query(
+      "SELECT n FROM Notification n "
+          + "JOIN FETCH n.sender "
+          + "JOIN FETCH n.child "
+          + "JOIN FETCH n.aiSummary "
+          + "WHERE n.receiver.id = :receiverId "
+          + "ORDER BY n.createTime DESC")
+  List<Notification> findAllByReceiverIdWithDetails(@Param("receiverId") Long receiverId);
+
+  long countByReceiverIdAndReadFalse(Long receiverId);
+
+  @Modifying
+  @Query(
+      "UPDATE Notification n SET n.read = true WHERE n.receiver.id = :receiverId AND n.read = false")
+  void markAllAsReadByReceiverId(@Param("receiverId") Long receiverId);
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/service/NotificationService.java
@@ -1,0 +1,22 @@
+package com.springboot.iboribe.domain.notification.service;
+
+import java.util.List;
+
+import com.springboot.iboribe.domain.aisummary.entity.AiSummary;
+import com.springboot.iboribe.domain.notification.dto.response.NotificationResponse;
+import com.springboot.iboribe.domain.notification.dto.response.NotificationStatusResponse;
+
+public interface NotificationService {
+
+  /** AI 요약 생성 시 같은 가족 구성원(본인 제외)에게 알림 생성 */
+  void createFamilyNotifications(AiSummary aiSummary, Long requesterId);
+
+  /** 내 알림 목록 조회 (최신순) */
+  List<NotificationResponse> getMyNotifications(Long userId);
+
+  /** 전체 알림 읽음 처리 */
+  void markAllAsRead(Long userId);
+
+  /** 읽지 않은 알림 존재 여부 및 개수 조회 */
+  NotificationStatusResponse getUnreadStatus(Long userId);
+}

--- a/src/main/java/com/springboot/iboribe/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,85 @@
+package com.springboot.iboribe.domain.notification.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.springboot.iboribe.domain.aisummary.entity.AiSummary;
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.notification.dto.response.NotificationResponse;
+import com.springboot.iboribe.domain.notification.dto.response.NotificationStatusResponse;
+import com.springboot.iboribe.domain.notification.entity.Notification;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
+import com.springboot.iboribe.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public void createFamilyNotifications(AiSummary aiSummary, Long requesterId) {
+    Child child = aiSummary.getMedicalRecord().getChild();
+    Family family = child.getFamily();
+    List<User> allMembers = userRepository.findAllByFamily(family);
+
+    User sender =
+        allMembers.stream()
+            .filter(user -> user.getId().equals(requesterId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new CustomException(
+                        com.springboot.iboribe.domain.auth.exception.AuthErrorCode.USER_NOT_FOUND));
+
+    allMembers.stream()
+        .filter(user -> !user.getId().equals(requesterId))
+        .forEach(
+            receiver -> {
+              Notification notification =
+                  Notification.builder()
+                      .receiver(receiver)
+                      .sender(sender)
+                      .child(child)
+                      .aiSummary(aiSummary)
+                      .build();
+              notificationRepository.save(notification);
+              log.info(
+                  "[Notification] 알림 생성 - receiverId: {}, senderId: {}, childId: {}",
+                  receiver.getId(),
+                  sender.getId(),
+                  child.getId());
+            });
+  }
+
+  @Override
+  public List<NotificationResponse> getMyNotifications(Long userId) {
+    return notificationRepository.findAllByReceiverIdWithDetails(userId).stream()
+        .map(NotificationResponse::from)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public void markAllAsRead(Long userId) {
+    notificationRepository.markAllAsReadByReceiverId(userId);
+  }
+
+  @Override
+  public NotificationStatusResponse getUnreadStatus(Long userId) {
+    long unreadCount = notificationRepository.countByReceiverIdAndReadFalse(userId);
+    return NotificationStatusResponse.of(unreadCount);
+  }
+}

--- a/src/main/java/com/springboot/iboribe/global/init/DemoDataLoader.java
+++ b/src/main/java/com/springboot/iboribe/global/init/DemoDataLoader.java
@@ -7,6 +7,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.springboot.iboribe.domain.aisummary.entity.AiSummary;
+import com.springboot.iboribe.domain.aisummary.repository.AiSummaryRepository;
 import com.springboot.iboribe.domain.child.entity.Child;
 import com.springboot.iboribe.domain.child.entity.ChildProfileColor;
 import com.springboot.iboribe.domain.child.repository.ChildRepository;
@@ -17,6 +19,8 @@ import com.springboot.iboribe.domain.family.repository.FamilyRepository;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecordSource;
 import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.entity.Notification;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
 
@@ -32,6 +36,8 @@ public class DemoDataLoader implements CommandLineRunner {
   private final FamilyRepository familyRepository;
   private final ChildRepository childRepository;
   private final MedicalRecordRepository medicalRecordRepository;
+  private final AiSummaryRepository aiSummaryRepository;
+  private final NotificationRepository notificationRepository;
   private final PasswordEncoder passwordEncoder;
 
   @Override
@@ -101,12 +107,13 @@ public class DemoDataLoader implements CommandLineRunner {
             createMedication("20260327", "약국", "뮤코졸정 (Mucosol Tab.)", "진해거담제", "4"),
             createMedication("20260327", "약국", "코미시럽 (Comy Syrup)", "항히스타민제", "4")));
 
-    createCodefMedicalRecordIfNotExists(
-        jiAn,
-        "삼성튼튼소아청소년과의원",
-        "20260418",
-        null,
-        List.of(createMedication("20260418", "외래", "움카민시럽", "기타의 호흡기관용약", "4")));
+    MedicalRecord jiAnSamsung =
+        createCodefMedicalRecordIfNotExists(
+            jiAn,
+            "삼성튼튼소아청소년과의원",
+            "20260418",
+            null,
+            List.of(createMedication("20260418", "외래", "움카민시럽", "기타의 호흡기관용약", "4")));
 
     createCodefMedicalRecordIfNotExists(
         seoYeon,
@@ -131,14 +138,15 @@ public class DemoDataLoader implements CommandLineRunner {
         "일반외래",
         List.of(createMedication("20260219", "외래", "부루펜시럽", "해열, 진통, 소염제", "3")));
 
-    createCodefMedicalRecordIfNotExists(
-        seoYeon,
-        "두리이비인후과의원",
-        "20260331",
-        "일반외래",
-        List.of(
-            createMedication("20260331", "외래", "시네츄라시럽", "진해거담제", "4"),
-            createMedication("20260331", "외래", "코미시럽", "항히스타민제", "4")));
+    MedicalRecord seoYeonDuri =
+        createCodefMedicalRecordIfNotExists(
+            seoYeon,
+            "두리이비인후과의원",
+            "20260331",
+            "일반외래",
+            List.of(
+                createMedication("20260331", "외래", "시네츄라시럽", "진해거담제", "4"),
+                createMedication("20260331", "외래", "코미시럽", "항히스타민제", "4")));
 
     createCodefMedicalRecordIfNotExists(
         seoYeon,
@@ -152,6 +160,30 @@ public class DemoDataLoader implements CommandLineRunner {
 
     createUserMedicalRecordIfNotExists(
         seoYeon, "예방접종 일정", "연세우리소아과의원", "20260520", "10:00", "예방접종 예정");
+
+    User dad = userRepository.findByUsername("dad_hyunwoo").orElseThrow();
+    User mom = userRepository.findByUsername("mom_jiyoon").orElseThrow();
+    User grandma = userRepository.findByUsername("grandma_soon").orElseThrow();
+
+    createDemoAiSummaryAndNotificationsIfNotExists(
+        jiAnSamsung,
+        grandma,
+        List.of(mom, dad),
+        jiAn,
+        "감기로 인한 기침·콧물, 움카민시럽 4일 처방",
+        "박지안 어린이는 기침과 콧물을 주 증상으로 내원하였습니다. 청진 상 폐음 정상이며 인후부 발적이 관찰되었습니다. "
+            + "바이러스성 상기도감염으로 진단하여 움카민시럽을 4일분 처방하였습니다. "
+            + "수분 섭취를 충분히 하고 실내 습도를 유지해 주세요.");
+
+    createDemoAiSummaryAndNotificationsIfNotExists(
+        seoYeonDuri,
+        dad,
+        List.of(mom, grandma),
+        seoYeon,
+        "중이염 의심으로 항히스타민제·진해거담제 처방",
+        "박서연 어린이는 귀 통증과 코막힘을 주 증상으로 내원하였습니다. 이경 검사 결과 우측 고막 발적이 관찰되어 "
+            + "삼출성 중이염 초기 소견으로 판단하였습니다. "
+            + "시네츄라시럽과 코미시럽을 4일분 처방하였으며, 1주일 후 경과 관찰을 권장합니다.");
 
     log.info("데모 데이터 초기화 완료");
   }
@@ -191,6 +223,20 @@ public class DemoDataLoader implements CommandLineRunner {
 
       log.info("데모 아빠 계정 생성 완료 - userId: {}", father.getId());
     }
+
+    if (!userRepository.existsByUsername("grandma_soon")) {
+      User grandmother =
+          userRepository.save(
+              User.builder()
+                  .name("박순자")
+                  .username("grandma_soon")
+                  .password(passwordEncoder.encode("Demo!1234"))
+                  .family(family)
+                  .familyRole(FamilyRole.GRANDMOTHER)
+                  .build());
+
+      log.info("데모 할머니 계정 생성 완료 - userId: {}", grandmother.getId());
+    }
   }
 
   private Child getOrCreateChild(Family family, String childName) {
@@ -207,13 +253,13 @@ public class DemoDataLoader implements CommandLineRunner {
                         .build()));
   }
 
-  private void createCodefMedicalRecordIfNotExists(
+  private MedicalRecord createCodefMedicalRecordIfNotExists(
       Child child,
       String hospitalName,
       String treatDate,
       String treatType,
       List<CodefMedicationResponse> medications) {
-    createMedicalRecordIfNotExists(
+    return createMedicalRecordIfNotExists(
         child,
         null,
         hospitalName,
@@ -244,7 +290,7 @@ public class DemoDataLoader implements CommandLineRunner {
         MedicalRecordSource.USER);
   }
 
-  private void createMedicalRecordIfNotExists(
+  private MedicalRecord createMedicalRecordIfNotExists(
       Child child,
       String title,
       String hospitalName,
@@ -254,25 +300,57 @@ public class DemoDataLoader implements CommandLineRunner {
       String memo,
       List<CodefMedicationResponse> medications,
       MedicalRecordSource source) {
-    boolean alreadyExists =
-        medicalRecordRepository.existsByChildAndHospitalNameAndTreatDate(
-            child, hospitalName, treatDate);
+    return medicalRecordRepository
+        .findByChildAndHospitalNameAndTreatDate(child, hospitalName, treatDate)
+        .orElseGet(
+            () ->
+                medicalRecordRepository.save(
+                    MedicalRecord.builder()
+                        .child(child)
+                        .title(title)
+                        .hospitalName(hospitalName)
+                        .treatDate(treatDate)
+                        .treatTime(treatTime)
+                        .memo(memo)
+                        .medications(medications)
+                        .source(source)
+                        .build()));
+  }
 
-    if (alreadyExists) {
+  private void createDemoAiSummaryAndNotificationsIfNotExists(
+      MedicalRecord medicalRecord,
+      User sender,
+      List<User> receivers,
+      Child child,
+      String oneLineSummary,
+      String medicalSummary) {
+    if (aiSummaryRepository.existsByMedicalRecord(medicalRecord)) {
       return;
     }
 
-    medicalRecordRepository.save(
-        MedicalRecord.builder()
-            .child(child)
-            .title(title)
-            .hospitalName(hospitalName)
-            .treatDate(treatDate)
-            .treatTime(treatTime)
-            .memo(memo)
-            .medications(medications)
-            .source(source)
-            .build());
+    AiSummary aiSummary =
+        aiSummaryRepository.save(
+            AiSummary.builder()
+                .medicalRecord(medicalRecord)
+                .oneLineSummary(oneLineSummary)
+                .medicalSummary(medicalSummary)
+                .build());
+
+    for (User receiver : receivers) {
+      notificationRepository.save(
+          Notification.builder()
+              .receiver(receiver)
+              .sender(sender)
+              .child(child)
+              .aiSummary(aiSummary)
+              .build());
+    }
+
+    log.info(
+        "[Demo] AI 요약 및 알림 생성 완료 - medicalRecordId: {}, senderId: {}, receiverCount: {}",
+        medicalRecord.getId(),
+        sender.getId(),
+        receivers.size());
   }
 
   private CodefMedicationResponse createMedication(


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #55 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #{Issue_number}를 적어주세요. -->

## 📝 요약(Summary)
AI 진료 요약 완료 시 같은 가족 구성원(본인 제외)에게 알림을 생성하는 기능을 구현했습니다.
또한 기존 진료 기록 ID가 필수였던 AI 요약 구조를 개선하여 녹음 먼저 → 요약 → 이후 진료 일정 별도 추가 흐름을 지원합니다.

**알림 기능**
- Notification 도메인 구현
- AI 요약 생성 시 가족 구성원에게 알림 자동 생성
- 알림 목록 조회 / 읽지 않은 알림 현황 / 전체 읽음 처리 API

**AI 진료 요약 유연화**
- POST /api/ai-summaries : recordId 없이 childId만으로 요약 가능
- recordId 없으면 source=AI 진료 기록 자동 생성
- recordId 있으면 기존 진료 기록에 연결 (childId 불필요)
- MedicalRecordSource에 AI 타입 추가

**데모 데이터**
- 데모 할머니 계정 추가
- 데모 AI 요약 및 알림 내역 추가
- 로그인, 데모 로그인 Swagger에 데모 계정 정보 주석 추가

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
