### PR TITLE
:bug: Fix: codef 하위 경로 Security permitAll 누락 수정

### DIFF
--- a/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
@@ -39,9 +39,9 @@ public class SecurityConfig {
                         "/api/hospital/**",
                         "/api/predict/**",
                         "/api/district/**",
-                        "/api/codef/medical-records",
-                        "/api/codef/children/register",
-                        "/api/codef/children/list")
+                        "/api/codef/medical-records/**",
+                        "/api/codef/children/register/**",
+                        "/api/codef/children/list/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #58 


## 📝 요약(Summary)
- `POST /api/codef/medical-records/2way` 요청 시 403 Forbidden 반환
- `/api/codef` 하위 경로 전체 인증 없이 접근 가능으로 수정


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
