### PR TITLE
✨ Feat: 어드민 사용자 관리 API 및 진료 내역 보안 강화

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
+++ b/src/main/java/com/springboot/iboribe/domain/codef/controller/CodefController.java
@@ -181,7 +181,7 @@ public class CodefController {
   }
 
   @Operation(
-      summary = "[토큰 X] CODEF 진료 및 투약정보 조회 2차 요청",
+      summary = "[토큰 O] CODEF 진료 및 투약정보 조회 2차 요청",
       description =
           """
           **Description**  \n

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/controller/MedicalRecordController.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/controller/MedicalRecordController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import com.springboot.iboribe.domain.medicalrecord.dto.request.MedicalRecordCreateRequest;
@@ -16,6 +17,7 @@ import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordUpd
 import com.springboot.iboribe.domain.medicalrecord.service.MedicalRecordCommandService;
 import com.springboot.iboribe.domain.medicalrecord.service.MedicalRecordQueryService;
 import com.springboot.iboribe.global.common.BaseResponse;
+import com.springboot.iboribe.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,19 +53,21 @@ public class MedicalRecordController {
           """)
   @GetMapping
   public ResponseEntity<BaseResponse<List<MedicalRecordSummaryResponse>>> getMedicalRecords(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) Integer year,
       @RequestParam(required = false) Integer month,
       @RequestParam(required = false) Long childId,
       @RequestParam(required = false) String date) {
 
+    Long userId = userDetails.getUserId();
     List<MedicalRecordSummaryResponse> response;
 
     if (date != null && !date.isBlank()) {
-      response = medicalRecordQueryService.getMedicalRecordsByDate(date);
+      response = medicalRecordQueryService.getMedicalRecordsByDate(userId, date);
     } else if (childId != null) {
-      response = medicalRecordQueryService.getMedicalRecordsByChild(childId, year, month);
+      response = medicalRecordQueryService.getMedicalRecordsByChild(userId, childId, year, month);
     } else {
-      response = medicalRecordQueryService.getMedicalRecords(year, month);
+      response = medicalRecordQueryService.getMedicalRecords(userId, year, month);
     }
 
     return ResponseEntity.ok(BaseResponse.success(200, "진료 내역 목록 조회 성공", response));

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.family.entity.Family;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
 
 public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Long> {
@@ -39,4 +40,20 @@ public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Lo
           + " WHERE mr.treatDate = :treatDate"
           + " ORDER BY mr.treatDate DESC")
   List<MedicalRecord> findAllByTreatDateOrderByTreatDateDesc(@Param("treatDate") String treatDate);
+
+  @Query(
+      "SELECT mr FROM MedicalRecord mr LEFT JOIN FETCH mr.aiSummary"
+          + " WHERE mr.child.family = :family AND mr.treatDate BETWEEN :startDate AND :endDate"
+          + " ORDER BY mr.treatDate DESC")
+  List<MedicalRecord> findAllByFamilyAndTreatDateBetweenOrderByTreatDateDesc(
+      @Param("family") Family family,
+      @Param("startDate") String startDate,
+      @Param("endDate") String endDate);
+
+  @Query(
+      "SELECT mr FROM MedicalRecord mr LEFT JOIN FETCH mr.aiSummary"
+          + " WHERE mr.child.family = :family AND mr.treatDate = :treatDate"
+          + " ORDER BY mr.treatDate DESC")
+  List<MedicalRecord> findAllByFamilyAndTreatDateOrderByTreatDateDesc(
+      @Param("family") Family family, @Param("treatDate") String treatDate);
 }

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryService.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryService.java
@@ -7,11 +7,12 @@ import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordSum
 
 public interface MedicalRecordQueryService {
 
-  List<MedicalRecordSummaryResponse> getMedicalRecords(int year, int month);
+  List<MedicalRecordSummaryResponse> getMedicalRecords(Long userId, int year, int month);
 
-  List<MedicalRecordSummaryResponse> getMedicalRecordsByChild(Long childId, int year, int month);
+  List<MedicalRecordSummaryResponse> getMedicalRecordsByChild(
+      Long userId, Long childId, int year, int month);
 
-  List<MedicalRecordSummaryResponse> getMedicalRecordsByDate(String date);
+  List<MedicalRecordSummaryResponse> getMedicalRecordsByDate(Long userId, String date);
 
   MedicalRecordDetailResponse getMedicalRecordDetail(Long recordId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordQueryServiceImpl.java
@@ -7,14 +7,18 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
 import com.springboot.iboribe.domain.child.entity.Child;
 import com.springboot.iboribe.domain.child.exception.ChildErrorCode;
 import com.springboot.iboribe.domain.child.repository.ChildRepository;
+import com.springboot.iboribe.domain.family.entity.Family;
 import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordDetailResponse;
 import com.springboot.iboribe.domain.medicalrecord.dto.response.MedicalRecordSummaryResponse;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
 import com.springboot.iboribe.domain.medicalrecord.exception.MedicalRecordErrorCode;
 import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.user.entity.User;
+import com.springboot.iboribe.domain.user.repository.UserRepository;
 import com.springboot.iboribe.global.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
@@ -24,17 +28,20 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MedicalRecordQueryServiceImpl implements MedicalRecordQueryService {
 
+  private final UserRepository userRepository;
   private final ChildRepository childRepository;
   private final MedicalRecordRepository medicalRecordRepository;
 
   @Override
-  public List<MedicalRecordSummaryResponse> getMedicalRecords(int year, int month) {
+  public List<MedicalRecordSummaryResponse> getMedicalRecords(Long userId, int year, int month) {
+    Family family = getFamily(userId);
+
     YearMonth yearMonth = YearMonth.of(year, month);
     String startDate = yearMonth.atDay(1).format(DateTimeFormatter.BASIC_ISO_DATE);
     String endDate = yearMonth.atEndOfMonth().format(DateTimeFormatter.BASIC_ISO_DATE);
 
     return medicalRecordRepository
-        .findAllByTreatDateBetweenOrderByTreatDateDesc(startDate, endDate)
+        .findAllByFamilyAndTreatDateBetweenOrderByTreatDateDesc(family, startDate, endDate)
         .stream()
         .map(MedicalRecordSummaryResponse::from)
         .toList();
@@ -42,11 +49,17 @@ public class MedicalRecordQueryServiceImpl implements MedicalRecordQueryService 
 
   @Override
   public List<MedicalRecordSummaryResponse> getMedicalRecordsByChild(
-      Long childId, int year, int month) {
+      Long userId, Long childId, int year, int month) {
+    Family family = getFamily(userId);
+
     Child child =
         childRepository
             .findById(childId)
             .orElseThrow(() -> new CustomException(ChildErrorCode.CHILD_NOT_FOUND));
+
+    if (!child.getFamily().getId().equals(family.getId())) {
+      throw new CustomException(ChildErrorCode.CHILD_NOT_FOUND);
+    }
 
     YearMonth yearMonth = YearMonth.of(year, month);
     String startDate = yearMonth.atDay(1).format(DateTimeFormatter.BASIC_ISO_DATE);
@@ -60,8 +73,12 @@ public class MedicalRecordQueryServiceImpl implements MedicalRecordQueryService 
   }
 
   @Override
-  public List<MedicalRecordSummaryResponse> getMedicalRecordsByDate(String date) {
-    return medicalRecordRepository.findAllByTreatDateOrderByTreatDateDesc(date).stream()
+  public List<MedicalRecordSummaryResponse> getMedicalRecordsByDate(Long userId, String date) {
+    Family family = getFamily(userId);
+
+    return medicalRecordRepository
+        .findAllByFamilyAndTreatDateOrderByTreatDateDesc(family, date)
+        .stream()
         .map(MedicalRecordSummaryResponse::from)
         .toList();
   }
@@ -75,5 +92,13 @@ public class MedicalRecordQueryServiceImpl implements MedicalRecordQueryService 
                 () -> new CustomException(MedicalRecordErrorCode.MEDICAL_RECORD_NOT_FOUND));
 
     return MedicalRecordDetailResponse.from(record);
+  }
+
+  private Family getFamily(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+    return user.getFamily();
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/controller/UserController.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.springboot.iboribe.domain.user.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +14,7 @@ import com.springboot.iboribe.global.exception.CustomException;
 import com.springboot.iboribe.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -48,5 +51,21 @@ public class UserController {
     }
     UserInfoResponse response = userService.getUserInfo(userDetails.getUserId());
     return ResponseEntity.ok(BaseResponse.success(200, "사용자 정보 조회 성공", response));
+  }
+
+  @SecurityRequirements
+  @Operation(summary = "[토큰 X] 전체 사용자 조회", description = "관리자용 전체 사용자 목록 조회")
+  @GetMapping("/admin/users")
+  public ResponseEntity<BaseResponse<List<UserInfoResponse>>> getAllUsers() {
+    List<UserInfoResponse> response = userService.getAllUsers();
+    return ResponseEntity.ok(BaseResponse.success(200, "전체 사용자 조회 성공", response));
+  }
+
+  @SecurityRequirements
+  @Operation(summary = "[토큰 X] 사용자 삭제", description = "관리자용 특정 사용자 삭제")
+  @DeleteMapping("/admin/users/{userId}")
+  public ResponseEntity<BaseResponse<Void>> deleteUser(@PathVariable Long userId) {
+    userService.deleteUser(userId);
+    return ResponseEntity.ok(BaseResponse.success(200, "사용자 삭제 성공", null));
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/service/UserService.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/service/UserService.java
@@ -1,8 +1,14 @@
 package com.springboot.iboribe.domain.user.service;
 
+import java.util.List;
+
 import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
 
 public interface UserService {
 
   UserInfoResponse getUserInfo(Long userId);
+
+  List<UserInfoResponse> getAllUsers();
+
+  void deleteUser(Long userId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
@@ -1,9 +1,13 @@
 package com.springboot.iboribe.domain.user.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.family.repository.FamilyRepository;
 import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
+  private final FamilyRepository familyRepository;
 
   @Override
   public UserInfoResponse getUserInfo(Long userId) {
@@ -26,5 +31,27 @@ public class UserServiceImpl implements UserService {
             .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
     return UserInfoResponse.from(user);
+  }
+
+  @Override
+  public List<UserInfoResponse> getAllUsers() {
+    return userRepository.findAll().stream().map(UserInfoResponse::from).toList();
+  }
+
+  @Override
+  @Transactional
+  public void deleteUser(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+    Family family = user.getFamily();
+    userRepository.delete(user);
+
+    boolean familyEmpty = userRepository.findAllByFamily(family).isEmpty();
+    if (familyEmpty) {
+      familyRepository.delete(family);
+    }
   }
 }

--- a/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
+++ b/src/main/java/com/springboot/iboribe/global/config/SecurityConfig.java
@@ -39,9 +39,10 @@ public class SecurityConfig {
                         "/api/hospital/**",
                         "/api/predict/**",
                         "/api/district/**",
-                        "/api/codef/medical-records/**",
+                        "/api/codef/medical-records",
                         "/api/codef/children/register/**",
-                        "/api/codef/children/list/**")
+                        "/api/codef/children/list/**",
+                        "/api/admin/**")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/src/main/java/com/springboot/iboribe/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/springboot/iboribe/global/filter/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
@@ -87,6 +88,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       SecurityContextHolder.clearContext();
       log.warn("[JWT] 유효하지 않은 Access Token");
       writeErrorResponse(response, 401, "유효하지 않은 Access Token입니다.");
+
+    } catch (UsernameNotFoundException e) {
+      SecurityContextHolder.clearContext();
+      log.warn("[JWT] 토큰의 사용자가 존재하지 않음 - username: {}", e.getMessage());
+      filterChain.doFilter(request, response);
     }
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #62 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #{Issue_number}를 적어주세요. -->

## 📝 요약(Summary)

- `GET /api/admin/users` 전체 사용자 목록 조회 API 추가 (토큰 불필요)
- `DELETE /api/admin/users/{userId}` 사용자 삭제 API 추가, 마지막 구성원 탈퇴 시 가족 코드 자동 삭제
- 진료 내역 조회 시 로그인 사용자의 가족 범위로 필터링하여 타 가족 데이터 노출 방지
- CODEF 진료 2차 요청(`/api/codef/medical-records/2way`) 인증 필수화 (토큰 없이 호출 시 403 반환)
- 탈퇴한 사용자의 토큰 재사용 시 `UsernameNotFoundException` 처리하여 500 방지

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
