### PR TITLE
:bug: Fix: 삭제 FK 제약 위반 수정 및 아이 삭제 API 추가

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/aisummary/repository/AiSummaryRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/repository/AiSummaryRepository.java
@@ -28,4 +28,8 @@ public interface AiSummaryRepository extends JpaRepository<AiSummary, Long> {
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM AiSummary a WHERE a.medicalRecord.id = :recordId")
   void deleteByMedicalRecordId(@Param("recordId") Long recordId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM AiSummary a WHERE a.medicalRecord.child.id = :childId")
+  void deleteAllByMedicalRecordChildId(@Param("childId") Long childId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/child/controller/ChildController.java
+++ b/src/main/java/com/springboot/iboribe/domain/child/controller/ChildController.java
@@ -76,4 +76,25 @@ public class ChildController {
 
     return ResponseEntity.ok(BaseResponse.success(200, "아이 정보 수정 성공", response));
   }
+
+  @Operation(
+      summary = "[토큰 O] 아이 삭제",
+      description =
+          """
+          **Authentication**  \n
+          - JWT 인증 필요  \n
+          - ACCESS_TOKEN 사용  \n
+
+          **Process**  \n
+          - 로그인 사용자의 가족 내 자녀 삭제  \n
+          - 해당 자녀의 진료 기록, AI 요약, 알림 데이터 함께 삭제  \n
+          """)
+  @DeleteMapping("/{childId}")
+  public ResponseEntity<BaseResponse<Void>> deleteChild(
+      @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long childId) {
+
+    childService.deleteChild(userDetails.getUserId(), childId);
+
+    return ResponseEntity.ok(BaseResponse.success(200, "아이 삭제 성공", null));
+  }
 }

--- a/src/main/java/com/springboot/iboribe/domain/child/service/ChildService.java
+++ b/src/main/java/com/springboot/iboribe/domain/child/service/ChildService.java
@@ -11,4 +11,6 @@ public interface ChildService {
   List<ChildResponse> getChildren(Long userId);
 
   ChildUpdateResponse updateChild(Long childId, ChildUpdateRequest request);
+
+  void deleteChild(Long loginUserId, Long childId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/child/service/ChildServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/child/service/ChildServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.springboot.iboribe.domain.aisummary.repository.AiSummaryRepository;
 import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
 import com.springboot.iboribe.domain.child.dto.request.ChildUpdateRequest;
 import com.springboot.iboribe.domain.child.dto.response.ChildResponse;
@@ -13,6 +14,8 @@ import com.springboot.iboribe.domain.child.entity.Child;
 import com.springboot.iboribe.domain.child.exception.ChildErrorCode;
 import com.springboot.iboribe.domain.child.repository.ChildRepository;
 import com.springboot.iboribe.domain.family.entity.Family;
+import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
 import com.springboot.iboribe.global.exception.CustomException;
@@ -26,6 +29,9 @@ public class ChildServiceImpl implements ChildService {
 
   private final UserRepository userRepository;
   private final ChildRepository childRepository;
+  private final NotificationRepository notificationRepository;
+  private final AiSummaryRepository aiSummaryRepository;
+  private final MedicalRecordRepository medicalRecordRepository;
 
   @Override
   public List<ChildResponse> getChildren(Long userId) {
@@ -56,5 +62,28 @@ public class ChildServiceImpl implements ChildService {
         request.getMemo());
 
     return ChildUpdateResponse.from(child);
+  }
+
+  @Override
+  @Transactional
+  public void deleteChild(Long loginUserId, Long childId) {
+    User loginUser =
+        userRepository
+            .findById(loginUserId)
+            .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+    Child child =
+        childRepository
+            .findById(childId)
+            .orElseThrow(() -> new CustomException(ChildErrorCode.CHILD_NOT_FOUND));
+
+    if (!child.getFamily().getId().equals(loginUser.getFamily().getId())) {
+      throw new CustomException(ChildErrorCode.CHILD_NOT_FOUND);
+    }
+
+    notificationRepository.deleteAllByChildId(childId);
+    aiSummaryRepository.deleteAllByMedicalRecordChildId(childId);
+    medicalRecordRepository.deleteAllByChildId(childId);
+    childRepository.delete(child);
   }
 }

--- a/src/main/java/com/springboot/iboribe/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/repository/FamilyRepository.java
@@ -10,5 +10,7 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
 
   boolean existsByFamilyCode(String familyCode);
 
+  boolean existsByFamilyCodeAndIdNot(String familyCode, Long id);
+
   Optional<Family> findByFamilyCode(String familyCode);
 }

--- a/src/main/java/com/springboot/iboribe/domain/family/service/FamilyServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/family/service/FamilyServiceImpl.java
@@ -13,6 +13,7 @@ import com.springboot.iboribe.domain.family.dto.response.FamilyMemberResponse;
 import com.springboot.iboribe.domain.family.entity.Family;
 import com.springboot.iboribe.domain.family.exception.FamilyErrorCode;
 import com.springboot.iboribe.domain.family.repository.FamilyRepository;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
 import com.springboot.iboribe.global.exception.CustomException;
@@ -27,6 +28,7 @@ public class FamilyServiceImpl implements FamilyService {
   private final UserRepository userRepository;
   private final FamilyRepository familyRepository;
   private final ChildRepository childRepository;
+  private final NotificationRepository notificationRepository;
 
   @Override
   public List<FamilyMemberResponse> getFamilyMembers(Long loginUserId) {
@@ -64,6 +66,7 @@ public class FamilyServiceImpl implements FamilyService {
 
     validateSameFamily(targetUser, loginUser.getFamily());
 
+    notificationRepository.deleteAllByUserId(memberId);
     userRepository.delete(targetUser);
   }
 
@@ -73,7 +76,7 @@ public class FamilyServiceImpl implements FamilyService {
     User loginUser = getUser(loginUserId);
     Family family = loginUser.getFamily();
 
-    if (familyRepository.existsByFamilyCode(request.getFamilyCode())) {
+    if (familyRepository.existsByFamilyCodeAndIdNot(request.getFamilyCode(), family.getId())) {
       throw new CustomException(FamilyErrorCode.ALREADY_EXIST_FAMILY_CODE);
     }
 

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/repository/MedicalRecordRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -56,4 +57,8 @@ public interface MedicalRecordRepository extends JpaRepository<MedicalRecord, Lo
           + " ORDER BY mr.treatDate DESC")
   List<MedicalRecord> findAllByFamilyAndTreatDateOrderByTreatDateDesc(
       @Param("family") Family family, @Param("treatDate") String treatDate);
+
+  @Modifying
+  @Query("DELETE FROM MedicalRecord mr WHERE mr.child.id = :childId")
+  void deleteAllByChildId(@Param("childId") Long childId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordCommandServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/medicalrecord/service/MedicalRecordCommandServiceImpl.java
@@ -15,6 +15,7 @@ import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecordSource;
 import com.springboot.iboribe.domain.medicalrecord.exception.MedicalRecordErrorCode;
 import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.global.exception.CustomException;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class MedicalRecordCommandServiceImpl implements MedicalRecordCommandServ
   private final ChildRepository childRepository;
   private final MedicalRecordRepository medicalRecordRepository;
   private final AiSummaryRepository aiSummaryRepository;
+  private final NotificationRepository notificationRepository;
 
   @Override
   public MedicalRecordCreateResponse createMedicalRecord(MedicalRecordCreateRequest request) {
@@ -59,7 +61,7 @@ public class MedicalRecordCommandServiceImpl implements MedicalRecordCommandServ
             .orElseThrow(
                 () -> new CustomException(MedicalRecordErrorCode.MEDICAL_RECORD_NOT_FOUND));
 
-    if (record.getSource() != MedicalRecordSource.USER) {
+    if (record.getSource() == MedicalRecordSource.CODEF) {
       throw new CustomException(MedicalRecordErrorCode.CODEF_RECORD_NOT_MODIFIABLE);
     }
 
@@ -90,10 +92,11 @@ public class MedicalRecordCommandServiceImpl implements MedicalRecordCommandServ
             .orElseThrow(
                 () -> new CustomException(MedicalRecordErrorCode.MEDICAL_RECORD_NOT_FOUND));
 
-    if (record.getSource() != MedicalRecordSource.USER) {
+    if (record.getSource() == MedicalRecordSource.CODEF) {
       throw new CustomException(MedicalRecordErrorCode.CODEF_RECORD_NOT_MODIFIABLE);
     }
 
+    notificationRepository.deleteAllByAiSummaryMedicalRecordId(recordId);
     aiSummaryRepository.deleteByMedicalRecordId(recordId);
     medicalRecordRepository.delete(record);
   }

--- a/src/main/java/com/springboot/iboribe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/springboot/iboribe/domain/notification/repository/NotificationRepository.java
@@ -26,4 +26,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   @Query(
       "UPDATE Notification n SET n.read = true WHERE n.receiver.id = :receiverId AND n.read = false")
   void markAllAsReadByReceiverId(@Param("receiverId") Long receiverId);
+
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.sender.id = :userId OR n.receiver.id = :userId")
+  void deleteAllByUserId(@Param("userId") Long userId);
+
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.child.id = :childId")
+  void deleteAllByChildId(@Param("childId") Long childId);
+
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.aiSummary.medicalRecord.id = :recordId")
+  void deleteAllByAiSummaryMedicalRecordId(@Param("recordId") Long recordId);
 }

--- a/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/user/service/UserServiceImpl.java
@@ -5,9 +5,14 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.springboot.iboribe.domain.aisummary.repository.AiSummaryRepository;
 import com.springboot.iboribe.domain.auth.exception.AuthErrorCode;
+import com.springboot.iboribe.domain.child.entity.Child;
+import com.springboot.iboribe.domain.child.repository.ChildRepository;
 import com.springboot.iboribe.domain.family.entity.Family;
 import com.springboot.iboribe.domain.family.repository.FamilyRepository;
+import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.domain.user.dto.response.UserInfoResponse;
 import com.springboot.iboribe.domain.user.entity.User;
 import com.springboot.iboribe.domain.user.repository.UserRepository;
@@ -22,6 +27,10 @@ public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
   private final FamilyRepository familyRepository;
+  private final NotificationRepository notificationRepository;
+  private final ChildRepository childRepository;
+  private final AiSummaryRepository aiSummaryRepository;
+  private final MedicalRecordRepository medicalRecordRepository;
 
   @Override
   public UserInfoResponse getUserInfo(Long userId) {
@@ -47,10 +56,18 @@ public class UserServiceImpl implements UserService {
             .orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
 
     Family family = user.getFamily();
+    notificationRepository.deleteAllByUserId(userId);
     userRepository.delete(user);
 
     boolean familyEmpty = userRepository.findAllByFamily(family).isEmpty();
     if (familyEmpty) {
+      List<Child> children = childRepository.findAllByFamily(family);
+      for (Child child : children) {
+        notificationRepository.deleteAllByChildId(child.getId());
+        aiSummaryRepository.deleteAllByMedicalRecordChildId(child.getId());
+        medicalRecordRepository.deleteAllByChildId(child.getId());
+      }
+      childRepository.deleteAll(children);
       familyRepository.delete(family);
     }
   }


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #68 

## 📝 요약(Summary)

- 유저/가족 구성원 삭제 시 notifications FK 제약 위반으로 500 오류가 발생하는 문제 수정
- 가족 비밀번호 변경 시 자기 코드가 중복으로 감지되는 버그 수정
- 또한 아이 삭제 API를 추가하고, AI 녹음으로 생성된 진료 기록도 수정/삭제할 수 있도록 개선

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).