### PR TITLE
:bug: Fix: AI 요약 삭제 시 알림 FK 제약 위반 수정

### DIFF
--- a/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryServiceImpl.java
+++ b/src/main/java/com/springboot/iboribe/domain/aisummary/service/AiSummaryServiceImpl.java
@@ -20,6 +20,7 @@ import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecord;
 import com.springboot.iboribe.domain.medicalrecord.entity.MedicalRecordSource;
 import com.springboot.iboribe.domain.medicalrecord.exception.MedicalRecordErrorCode;
 import com.springboot.iboribe.domain.medicalrecord.repository.MedicalRecordRepository;
+import com.springboot.iboribe.domain.notification.repository.NotificationRepository;
 import com.springboot.iboribe.domain.notification.service.NotificationService;
 import com.springboot.iboribe.global.exception.CustomException;
 
@@ -37,6 +38,7 @@ public class AiSummaryServiceImpl implements AiSummaryService {
   private final ChildRepository childRepository;
   private final AiSummaryMapper aiSummaryMapper;
   private final NotificationService notificationService;
+  private final NotificationRepository notificationRepository;
 
   @Override
   @Transactional
@@ -75,6 +77,7 @@ public class AiSummaryServiceImpl implements AiSummaryService {
       throw new CustomException(AiSummaryErrorCode.AI_SUMMARY_NOT_FOUND);
     }
 
+    notificationRepository.deleteAllByAiSummaryMedicalRecordId(recordId);
     aiSummaryRepository.deleteByMedicalRecordId(recordId);
   }
 


### PR DESCRIPTION
## #️⃣ Issue Number

- Close #91 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #{Issue_number}를 적어주세요. -->

## 📝 요약(Summary)

- AI 요약 삭제 시 notifications 테이블에서 ai_summary_id를 참조하고 있어 FK 제약 위반으로 500 오류가 발생하는 문제 수정 
- AI 요약 삭제 전 연관 알림을 먼저 삭제하도록 순서 변경

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [x] 버그 수정


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
